### PR TITLE
missing help in mbop

### DIFF
--- a/tools/mbop_main.cpp
+++ b/tools/mbop_main.cpp
@@ -16,6 +16,7 @@ static int help(const char *argv0)
 {
 	fprintf(stderr, "Usage: %s ...\n", argv0);
 	fprintf(stderr, "\tunload $maildir    Execute the UNLOAD RPC for the given mailbox\n");
+	fprintf(stderr, "\tvacuum $maildir    Execute the VACUUM RPC for the given mailbox\n");
 	return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
add vacuum option to help-output