### PR TITLE
Ticket fix: Sync deleted mailbox on Thunderbird when they are deleted on G-Web

### DIFF
--- a/exch/midb/mail_engine.cpp
+++ b/exch/midb/mail_engine.cpp
@@ -4331,15 +4331,6 @@ static void mail_engine_notification_proc(const char *dir,
 		folder_id = n->folder_id;
 		message_id = n->message_id;
 		mail_engine_add_notification_message(pidb.get(), folder_id, message_id);
-		snprintf(sql_string, std::size(sql_string), "SELECT name FROM"
-		          " folders WHERE folder_id=%llu", LLU{folder_id});
-		auto pstmt = gx_sql_prep(pidb->psqlite, sql_string);
-		if (pstmt == nullptr || pstmt.step() != SQLITE_ROW)
-			break;
-		snprintf(temp_buff, 1280, "FOLDER-TOUCH %s %s",
-		         pidb->username.c_str(), pstmt.col_text(0));
-		pstmt.finalize();
-		system_services_broadcast_event(temp_buff);
 		break;
 	}
 	case db_notify_type::folder_created: {
@@ -4416,6 +4407,19 @@ static void mail_engine_notification_proc(const char *dir,
 	}
 	default:
 		break;
+	}
+
+	// broadcasts a FOLDER-TOUCH event using gromox-event protocol
+	if (folder_id != 0) {  // Check if folder_id is assigned
+		snprintf(sql_string, std::size(sql_string), "SELECT name FROM"
+							" folders WHERE folder_id=%llu", LLU{folder_id});
+		auto pstmt = gx_sql_prep(pidb->psqlite, sql_string);
+		if (pstmt == nullptr || pstmt.step() != SQLITE_ROW)
+				return;
+		snprintf(temp_buff, 1280, "FOLDER-TOUCH %s %s",
+							pidb->username.c_str(), pstmt.col_text(0));
+		pstmt.finalize();
+		system_services_broadcast_event(temp_buff);
 	}
 }
 


### PR DESCRIPTION
### - Reason of the issue

When a new email is received, **`gromox-midb`** broadcasts a notification using the **`gromox-event`** protocol ( `FOLDER-TOUCH {username} {foldername}`, whereas `{foldername}` is "inbox", "outbox", "trash", …).

**`gromox-imap`** has an event listener that handles these broadcasting notifications. **`gromox-imap`** parses and sends a command to the Thunderbird client to refresh the desired folders of the mailbox.

But, this flow I described above is only defined when a new mail is received. All other cases don't have this flow.

In the code snippet, notice the changes between **`db_notify_type::new_mail`** and other cases. [`exch/midb/mail_engine.cpp`]
In case of **`db_notify_type::new_mail`**, it calls **`system_services_broadcast_event(temp_buff)`** function.
```
switch (pdb_notify->type) {
    case db_notify_type::new_mail: {
        ...
        system_services_broadcast_event(temp_buff);
        break;
    }
    case db_notify_type::folder_created: {
        ...
        break;
    }
    case db_notify_type::message_created: {
        ...
        break;
    }
    case db_notify_type::folder_deleted: {
        ...
        break;
    }
    case db_notify_type::message_deleted: {
        ...
        break;
    }
    case db_notify_type::folder_modified: {
        ...
        break;
    }
    case db_notify_type::message_modified: {
        ...
        break;
    }
    case db_notify_type::folder_moved: {
        ...
        break;
    }
    case db_notify_type::message_moved: {
        ...
        break;
    }
    case db_notify_type::folder_copied: {
        ...
        break;
    }
    case db_notify_type::message_copied: {
        ...
        break;
    }
    default:
        break;
}
```

### - Implementation & how to fix

To fix the issue, I moved the  **`system_services_broadcast_event(temp_buff);`**  from inside of **`case db_notify_type::new_mail`** to outside of the **`SWITCH ~ CASE`** statement.

```
switch (pdb_notify->type) {
    ...
}

system_services_broadcast_event(temp_buff);
```
Eventually, not only in case of new_mail received, when something is changed on G-Web/OL, and DB is updated, **`FOLDER-TOUCH`** event is broadcasted, and **`gromox-imap`** receives the event and refreshes the desired mailboxes.
