### PR TITLE
mapi_lib: add duration_cast in time_point rop_util_rtime_to_unix2

### DIFF
--- a/lib/mapi/rop_util.cpp
+++ b/lib/mapi/rop_util.cpp
@@ -200,7 +200,9 @@ gromox::time_point rop_util_nttime_to_unix2(uint64_t nt_time)
 }
 
 gromox::time_point rop_util_rtime_to_unix2(uint32_t t)
-{return gromox::time_point(nt_dur(rop_util_rtime_to_nttime(t))-nt_offset);}
+{
+	return gromox::time_point(std::chrono::duration_cast<gromox::time_point::duration>(nt_dur(rop_util_rtime_to_nttime(t))-nt_offset));
+}
 
 time_t rop_util_rtime_to_unix(uint32_t t)
 {


### PR DESCRIPTION

lib/mapi/rop_util.cpp:204:9: error: no matching conversion for functional-style cast from 'typename common_type<duration<unsigned long long, ratio<1, 10000000>>, duration<unsigned long long, ratio<1, 10000000>>>::type' (aka 'duration<unsigned long long, ratio<__static_gcd<ratio<1, 10000000>::num, ratio<1, 10000000>::num>::value, __static_lcm<ratio<1, 10000000>::den, ratio<1, 10000000>::den>::value>>') to 'gromox::time_point' (aka 'time_point<std::chrono::system_clock>') {return gromox::time_point(nt_dur(rop_util_rtime_to_nttime(t))-nt_offset);}