### PR TITLE
Solve reopened-419 (Syncing deleted mails from G-Web -> Thunderbird)

### DIFF
--- a/mra/imap/imap.hpp
+++ b/mra/imap/imap.hpp
@@ -135,7 +135,7 @@ extern gromox::time_point imap_parser_get_context_timestamp(const schedule_conte
 extern SCHEDULE_CONTEXT **imap_parser_get_contexts_list();
 extern int imap_parser_threads_event_proc(int action);
 extern void imap_parser_bcast_touch(const imap_context *, const char *user, const char *folder);
-extern void imap_parser_echo_modify(imap_context *, STREAM *, unsigned int report = REPORT_NEWMAIL | REPORT_FLAGS);
+extern void imap_parser_echo_modify(imap_context *, STREAM *, unsigned int report = REPORT_NEWMAIL | REPORT_FLAGS | REPORT_EXPUNGE);
 extern void imap_parser_bcast_flags(const imap_context &, uint32_t uid);
 extern void imap_parser_add_select(IMAP_CONTEXT *);
 extern void imap_parser_bcast_expunge(const IMAP_CONTEXT &, const std::vector<MITEM *> &);


### PR DESCRIPTION
### - The reason why this issue is happening again.

These 4 commits slightly changed the flow of synchronizing deleted mails from G-Web -> Thunderbird.

```
https://github.com/grommunio/gromox/commit/0bd3586831385348c782d7bdb4c995adeeac1b68
https://github.com/grommunio/gromox/commit/5fb5e9a205849289ebfcea12321993479f555c60
https://github.com/grommunio/gromox/commit/5d1c023ad568d235ab204555138e3de036ceabcc
https://github.com/grommunio/gromox/commit/15a5b8ff91ad4e81573152bde355af251788d308
```

``ps_stat_notifying()`` function defined in ``mra/imap/imap_parser.cpp``  is called to refresh the desired clients' mail boxes.
And ``ps_stat_notifying()`` calls ``imap_parser_echo_modify()`` function inside.

- Here is the declaration of ``imap_parser_echo_modify()``.
Notice the third parameter - ``report`` - It has default value ``REPORT_NEWMAIL | REPORT_FLAGS``
```
extern void imap_parser_echo_modify(
    imap_context *,
    STREAM *,
    unsigned int report = REPORT_NEWMAIL | REPORT_FLAGS);
```

- And here is the usage of ``imap_parser_echo_modify()``in ``ps_stat_notifying()``.
  It doesn't pass the third parameter. It means that the third parameter always has the default value -``REPORT_NEWMAIL | REPORT_FLAGS`` .
  Eventually, inside of ``imap_parser_echo_modify()``, ``IF`` conditions related to ``REPORT_EXPUNGE`` are always skipped and nothing happens.

### - How to fix
To fix this issue, I changed the default value of the ``report`` parameter in the ``imap_parser_echo_modify()`` declaration part to ``REPORT_NEWMAIL | REPORT_FLAGS | REPORT_EXPUNGE``.

Here is the code snippet.
```
extern void imap_parser_echo_modify(imap_context *, 
      STREAM *, 
      unsigned int report = REPORT_NEWMAIL | REPORT_FLAGS | REPORT_EXPUNGE);
```