### PR TITLE
doc: refer to /var/lib/kopano/attachments

### DIFF
--- a/doc/gromox-kdb2mt.8
+++ b/doc/gromox-kdb2mt.8
@@ -171,11 +171,11 @@ Password for the source SQL connection.
 When Gromox and Kopano run on different hosts, and you wish to have the Gromox
 host to initiate all necessary connections.
 .PP
-Step 1. Establish an sshfs mount. This is used to get at the attachment
+Step 1. Establish an sshfs mount. This is used to get at the attachments
 directory of Kopano Core. Command:
 .PP
 .RS 4
-sshfs root@kp:/var/lib/kopano/attachment /mnt
+sshfs root@kp:/var/lib/kopano/attachments /mnt
 .RE
 .PP
 For this to work, root logins need to be possible in some form (password or


### PR DESCRIPTION
Kopano Core used `/var/lib/kopano/attachments`, not `/var/lib/kopano/attachment`.

See also: https://github.com/Kopano-dev/kopano-core/blob/76cf85b895b5fdfada7be422f4a341950ea469bf/provider/server/ECServer.cpp#L1071