### PR TITLE
define process names for syslog

### DIFF
--- a/exch/http/main.cpp
+++ b/exch/http/main.cpp
@@ -134,7 +134,7 @@ static bool http_reload_config(std::shared_ptr<CONFIG_FILE> xcfg = nullptr,
 		mlog(LV_ERR, "config_file_init %s: %s", opt_config_file, strerror(errno));
 		return false;
 	}
-	mlog_init(cfg->get_value("http_log_file"), cfg->get_ll("http_log_level"));
+	mlog_init("gromox-http", cfg->get_value("http_log_file"), cfg->get_ll("http_log_level"));
 	g_http_debug = cfg->get_ll("http_debug");
 	g_enforce_auth = cfg->get_ll("http_enforce_auth");
 	g_msrpc_debug = cfg->get_ll("msrpc_debug");

--- a/exch/midb/main.cpp
+++ b/exch/midb/main.cpp
@@ -124,7 +124,7 @@ static bool midb_reload_config(std::shared_ptr<config_file> gxconfig = nullptr,
 		mlog(LV_ERR, "config_file_init %s: %s", opt_config_file, strerror(errno));
 		return false;
 	}
-	mlog_init(pconfig->get_value("midb_log_file"), pconfig->get_ll("midb_log_level"));
+	mlog_init("gromox-midb", pconfig->get_value("midb_log_file"), pconfig->get_ll("midb_log_level"));
 	g_cmd_debug = pconfig->get_ll("midb_cmd_debug");
 	g_midb_cache_interval = pconfig->get_ll("midb_cache_interval");
 	g_midb_reload_interval = pconfig->get_ll("midb_reload_interval");

--- a/exch/zcore/main.cpp
+++ b/exch/zcore/main.cpp
@@ -164,7 +164,7 @@ static bool zcore_reload_config(std::shared_ptr<CONFIG_FILE> gxcfg = nullptr,
 		       opt_config_file, strerror(errno));
 		return false;
 	}
-	mlog_init(pconfig->get_value("zcore_log_file"), pconfig->get_ll("zcore_log_level"));
+	mlog_init("gromox-zcore", pconfig->get_value("zcore_log_file"), pconfig->get_ll("zcore_log_level"));
 	g_zrpc_debug = pconfig->get_ll("zrpc_debug");
 	g_oxcical_allday_ymd = pconfig->get_ll("oxcical_allday_ymd");
 	zcore_max_obh_per_session = pconfig->get_ll("zcore_max_obh_per_session");

--- a/include/gromox/util.hpp
+++ b/include/gromox/util.hpp
@@ -112,7 +112,7 @@ extern GX_EXPORT const std::string_view *wintz_to_tzdef(const char *);
 extern GX_EXPORT bool get_digest(const char *src, const char *tag, char *out, size_t outmax);
 extern GX_EXPORT bool set_digest(char *src, size_t length, const char *tag, const char *v);
 extern GX_EXPORT bool set_digest(char *src, size_t length, const char *tag, uint64_t v);
-extern GX_EXPORT void mlog_init(const char *file, unsigned int level);
+extern GX_EXPORT void mlog_init(const char *ident, const char *file, unsigned int level);
 extern GX_EXPORT void mlog(unsigned int level, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 extern GX_EXPORT int pthread_create4(pthread_t *, std::nullptr_t, void *(*)(void *), void * = nullptr) noexcept;
 extern GX_EXPORT int class_match_prefix(const char *h, const char *n);

--- a/lib/rfbl.cpp
+++ b/lib/rfbl.cpp
@@ -1110,7 +1110,7 @@ errno_t tmpfile::link_to(const char *newpath)
 	return 0;
 }
 
-void mlog_init(const char *filename, unsigned int max_level)
+void mlog_init(const char *ident, const char *filename, unsigned int max_level)
 {
 	g_max_loglevel = max_level;
 	if (filename == nullptr || *filename == '\0' || strcmp(filename, "-") == 0)
@@ -1120,7 +1120,7 @@ void mlog_init(const char *filename, unsigned int max_level)
 	if (g_logfp == nullptr && getppid() == 1 && getenv("JOURNAL_STREAM") != nullptr)
 		g_log_syslog = true;
 	if (g_log_syslog) {
-		openlog(nullptr, LOG_PID, LOG_MAIL);
+		openlog(ident, LOG_PID, LOG_MAIL);
 		setlogmask((1 << (max_level + 2)) - 1);
 		return;
 	}

--- a/mda/delivery_app/main.cpp
+++ b/mda/delivery_app/main.cpp
@@ -82,7 +82,7 @@ static bool delivery_reload_config(std::shared_ptr<CONFIG_FILE> cfg)
 		mlog(LV_ERR, "config_file_init %s: %s", opt_config_file, strerror(errno));
 		return false;
 	}
-	mlog_init(cfg->get_value("lda_log_file"), cfg->get_ll("lda_log_level"));
+	mlog_init("gromox-delivery", cfg->get_value("lda_log_file"), cfg->get_ll("lda_log_level"));
 	return true;
 }
 

--- a/mda/smtp/main.cpp
+++ b/mda/smtp/main.cpp
@@ -360,7 +360,7 @@ int main(int argc, const char **argv)
 	if (!dq_reload_config(gxconfig, g_config_file))
 		return EXIT_FAILURE;
 
-	mlog_init(g_config_file->get_value("lda_log_file"), g_config_file->get_ll("lda_log_level"));
+	mlog_init("gromox-delivery-queue", g_config_file->get_value("lda_log_file"), g_config_file->get_ll("lda_log_level"));
 	if (0 != resource_run()) { 
 		mlog(LV_ERR, "system: failed to load resources");
 		return EXIT_FAILURE;

--- a/mra/imap/main.cpp
+++ b/mra/imap/main.cpp
@@ -158,7 +158,7 @@ static bool imap_reload_config(std::shared_ptr<config_file> gxcfg = nullptr,
 		fprintf(stderr, "config_file_init %s: %s\n", opt_config_file, strerror(errno));
 		return false;
 	}
-	mlog_init(cfg->get_value("imap_log_file"), cfg->get_ll("imap_log_level"));
+	mlog_init("gromox-imap", cfg->get_value("imap_log_file"), cfg->get_ll("imap_log_level"));
 	g_imapcmd_debug = cfg->get_ll("imap_cmd_debug");
 	g_rfc9051_enable = cfg->get_ll("imap_rfc9051");
 	return true;

--- a/mra/pop3/main.cpp
+++ b/mra/pop3/main.cpp
@@ -135,7 +135,7 @@ static bool pop3_reload_config(std::shared_ptr<config_file> gxcfg = nullptr,
 		printf("config_file_init %s: %s\n", opt_config_file, strerror(errno));
 		return false;
 	}
-	mlog_init(pconfig->get_value("pop3_log_file"), pconfig->get_ll("pop3_log_level"));
+	mlog_init("gromox-pop3", pconfig->get_value("pop3_log_file"), pconfig->get_ll("pop3_log_level"));
 	g_popcmd_debug = pconfig->get_ll("pop3_cmd_debug");
 	return true;
 }

--- a/tools/event.cpp
+++ b/tools/event.cpp
@@ -211,7 +211,7 @@ int main(int argc, const char **argv)
 	if (pconfig == nullptr)
 		return EXIT_FAILURE;
 
-	mlog_init(pconfig->get_value("event_log_file"), pconfig->get_ll("event_log_level"));
+	mlog_init("gromox-event", pconfig->get_value("event_log_file"), pconfig->get_ll("event_log_level"));
 	auto listen_ip = pconfig->get_value("event_listen_ip");
 	uint16_t listen_port = pconfig->get_ll("event_listen_port");
 	printf("[system]: listen address is [%s]:%hu\n",

--- a/tools/timer.cpp
+++ b/tools/timer.cpp
@@ -234,7 +234,7 @@ int main(int argc, const char **argv)
 	if (pconfig == nullptr)
 		return EXIT_FAILURE;
 
-	mlog_init(pconfig->get_value("timer_log_file"), pconfig->get_ll("timer_log_level"));
+	mlog_init("gromox-timer", pconfig->get_value("timer_log_file"), pconfig->get_ll("timer_log_level"));
 	g_list_path = pconfig->get_value("timer_state_path");
 	uint16_t listen_port = pconfig->get_ll("timer_listen_port");
 	auto listen_ip = pconfig->get_value("timer_listen_ip");


### PR DESCRIPTION
When using syslog, the process name is currently empty. To fix this, the syslog ident has to be set explicitly.