### PR TITLE
Add gromox-cleanup.sh script

### DIFF
--- a/grommunio-mailbox-maintenance.timer
+++ b/grommunio-mailbox-maintenance.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Grommunio Mailbox Maintenance / Cleanup
+Documentation=man:gromox-mbop(8)
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+AccuracySec=15m
+Persistent=true
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/system/grommunio-mailbox-maintenance.service
+++ b/system/grommunio-mailbox-maintenance.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Grommunio Mailbox Maintenance / Cleanup
+Documentation=man:gromox-mbop(8)
+
+[Service]
+Environment=SOFTDELETE_TIMESTAMP=30d20h
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
+Type=oneshot
+ExecStart=/usr/sbin/grommunio-cleanup

--- a/tools/gromox-cleanup.sh
+++ b/tools/gromox-cleanup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+SCRIPT_BUILD=202411254
+
+GROMOX_MAILDIR_PATH="/var/lib/gromox"
+SOFTDELETE_TIMESTAMP="30d20h"
+
+function TrapQuit {
+        local exitcode=0
+
+        if [ "$SCRIPT_GOOD" == true ]; then
+                log "Cleanup operation finished with success after ${SECONDS} seconds"
+                exitcode=0
+        else
+                log "Cleanup operation failed after ${SECONDS}" "ERROR"
+                exitcode=1
+        fi
+        exit $exitcode
+}
+
+
+function log {
+        local log_line="${1}"
+        local level="${2}"
+
+        if [ "${level}" != "" ]; then
+                log_line="${level}: ${log_line}"
+        fi
+
+        if [ "${level}" == "ERROR" ]; then
+                SCRIPT_GOOD=false
+                echo "ERROR: ${log_line}" >> "${LOG_FILE}"
+                (>&2 echo -e "$log_line")
+        else
+                echo "${log_line}" >> "${LOG_FILE}"
+                echo "${log_line}"
+        fi
+}
+
+
+function cleanup {
+        for maildir in $(grommunio-admin user query maildir | awk '{if ($1~gromox_mail) {print $1}}' gromox="${GROMOX_MAILDIR_PATH}"); do
+                if [ "$SOFTDELETE_TIMESTAMP" != "" ]; then
+                        log "Purging soft deletions for ${maildir}"
+                        start_time=${SECONDS}
+                        gromox-mbop -d "${maildir}" purge-softdelete -r -t "$SOFTDELETE_TIMESTAMP" IPM_SUBTREE >> "${LOG_FILE}" 2>&1
+                        if [ $? -eq 0 ]; then
+                                log "Operation took $((${SECONDS}-${start_time})) for ${maildir}"
+                        else
+                                log "Failed to purge soft deletions for ${maildir}" "ERROR"
+                        fi
+                fi
+                log "Purging datafiles for ${maildir}"
+                start_time=${SECONDS}
+                gromox-mbop -d "${maildir}" purge-datafiles >> "${LOG_FILE}" 2>&1
+                if [ $? -eq 0 ]; then
+                        log "Operation took $((${SECONDS}-${start_time}))  for ${maildir}"
+                else
+                        log "Failed to purge datafiles for ${maildir}" "ERROR"
+                fi
+        done
+}
+
+## ENTRY POINT
+
+trap TrapQuit TERM EXIT HUP QUIT
+set -o pipefail
+set -o errtrace
+SCRIPT_GOOD=true
+
+## Default log file
+
+SCRIPT_NAME=$(basename "$0")
+if [ -w /var/log ]; then
+        LOG_FILE="/var/log/${SCRIPT_NAME}.log"
+elif ([ "${HOME}" != "" ] && [ -w "${HOME}" ]); then
+        LOG_FILE="${HOME}/${SCRIPT_NAME}.log"
+elif [ -w . ]; then
+        LOG_FILE="./${SCRIPT_NAME}.log"
+else
+        LOG_FILE="/tmp/${SCRIPT_NAME}.log"
+fi
+
+cleanup

--- a/tools/gromox-cleanup.sh
+++ b/tools/gromox-cleanup.sh
@@ -30,10 +30,8 @@ function log {
 
         if [ "${level}" == "ERROR" ]; then
                 SCRIPT_GOOD=false
-                echo "ERROR: ${log_line}" >> "${LOG_FILE}"
                 (>&2 echo -e "$log_line")
         else
-                echo "${log_line}" >> "${LOG_FILE}"
                 echo "${log_line}"
         fi
 }
@@ -44,7 +42,7 @@ function cleanup {
                 if [ "$SOFTDELETE_TIMESTAMP" != "" ]; then
                         log "Purging soft deletions for ${maildir}"
                         start_time=${SECONDS}
-                        "${BIN_DIR}/gromox-mbop" -d "${maildir}" purge-softdelete -r -t "$SOFTDELETE_TIMESTAMP" IPM_SUBTREE >> "${LOG_FILE}" 2>&1
+                        "${BIN_DIR}/gromox-mbop" -d "${maildir}" purge-softdelete -r -t "$SOFTDELETE_TIMESTAMP" IPM_SUBTREE
                         if [ $? -eq 0 ]; then
                                 log "Operation took $((${SECONDS}-${start_time})) for ${maildir}"
                         else
@@ -53,7 +51,7 @@ function cleanup {
                 fi
                 log "Purging datafiles for ${maildir}"
                 start_time=${SECONDS}
-                "${BIN_DIR}/gromox-mbop" -d "${maildir}" purge-datafiles >> "${LOG_FILE}" 2>&1
+                "${BIN_DIR}/gromox-mbop" -d "${maildir}" purge-datafiles
                 if [ $? -eq 0 ]; then
                         log "Operation took $((${SECONDS}-${start_time}))  for ${maildir}"
                 else
@@ -68,18 +66,5 @@ trap TrapQuit TERM EXIT HUP QUIT
 set -o pipefail
 set -o errtrace
 SCRIPT_GOOD=true
-
-## Default log file
-
-SCRIPT_NAME=$(basename "$0")
-if [ -w /var/log ]; then
-        LOG_FILE="/var/log/${SCRIPT_NAME}.log"
-elif ([ "${HOME}" != "" ] && [ -w "${HOME}" ]); then
-        LOG_FILE="${HOME}/${SCRIPT_NAME}.log"
-elif [ -w . ]; then
-        LOG_FILE="./${SCRIPT_NAME}.log"
-else
-        LOG_FILE="/tmp/${SCRIPT_NAME}.log"
-fi
 
 cleanup

--- a/tools/gromox-cleanup.sh
+++ b/tools/gromox-cleanup.sh
@@ -1,9 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-SCRIPT_BUILD=202411254
+SCRIPT_BUILD=2024112502
+BIN_DIR=/usr/sbin
 
-GROMOX_MAILDIR_PATH="/var/lib/gromox"
-SOFTDELETE_TIMESTAMP="30d20h"
+GROMOX_MAILDIR_PATH="$("${BIN_DIR}/grommunio-admin" config get options.userPrefix)"
+SOFTDELETE_TIMESTAMP=${SOFTDELETE_TIMESTAMP:-30d20h}
 
 function TrapQuit {
         local exitcode=0
@@ -39,11 +40,11 @@ function log {
 
 
 function cleanup {
-        for maildir in $(grommunio-admin user query maildir | awk '{if ($1~gromox_mail) {print $1}}' gromox="${GROMOX_MAILDIR_PATH}"); do
+        for maildir in $("${BIN_DIR}/grommunio-admin" user query maildir | awk '{if ($1~gromox_mail) {print $1}}' gromox="${GROMOX_MAILDIR_PATH}"); do
                 if [ "$SOFTDELETE_TIMESTAMP" != "" ]; then
                         log "Purging soft deletions for ${maildir}"
                         start_time=${SECONDS}
-                        gromox-mbop -d "${maildir}" purge-softdelete -r -t "$SOFTDELETE_TIMESTAMP" IPM_SUBTREE >> "${LOG_FILE}" 2>&1
+                        "${BIN_DIR}/gromox-mbop" -d "${maildir}" purge-softdelete -r -t "$SOFTDELETE_TIMESTAMP" IPM_SUBTREE >> "${LOG_FILE}" 2>&1
                         if [ $? -eq 0 ]; then
                                 log "Operation took $((${SECONDS}-${start_time})) for ${maildir}"
                         else
@@ -52,7 +53,7 @@ function cleanup {
                 fi
                 log "Purging datafiles for ${maildir}"
                 start_time=${SECONDS}
-                gromox-mbop -d "${maildir}" purge-datafiles >> "${LOG_FILE}" 2>&1
+                "${BIN_DIR}/gromox-mbop" -d "${maildir}" purge-datafiles >> "${LOG_FILE}" 2>&1
                 if [ $? -eq 0 ]; then
                         log "Operation took $((${SECONDS}-${start_time}))  for ${maildir}"
                 else


### PR DESCRIPTION
Purpose of this PR: Keep gromox folders clean

While playing with gromox, I wrote a prometheus exporter [here](https://github.com/netinvent/grommunio_exporter) after which I noticed that some mailboxes were quite huge, even when the ondisk maidir was twice as small.

Discussing with @WalterHof and @crpb, they suggested to run various cleanups.
I was wondering why that wasn't "standard" for Grommunio, so here's a script that perhaps should be added by default to Grommunio's setup via a systemd timer / or even as fs-hook/thaw for VM environments.

Currently tested on two Grommunio servers running gromox 2.37.

Thanks for considering this.
