### PR TITLE
cleaner: Environment vars

### DIFF
--- a/system/cleaner.cfg
+++ b/system/cleaner.cfg
@@ -1,0 +1,1 @@
+PURGETIME=30d

--- a/system/gromox-cleaner.service
+++ b/system/gromox-cleaner.service
@@ -2,13 +2,16 @@
 Description=Gromox mailbox cleaner
 
 [Service]
-Type=oneshot
-ExecStart=/usr/sbin/gromox-mbop foreach.here.mb ( purge-softdelete -d 30d -r / ) ( purge-datafiles )
+# Fallback if EnvironmentFile hasn't got any value
+Environment=PURGETIME=30d
+EnvironmentFile=/etc/gromox/cleaner.cfg
+ExecStart=/usr/sbin/gromox-mbop foreach.here.mb ( purge-softdelete -d ${PURGETIME} -r / ) ( purge-datafiles )
+MemoryDenyWriteExecute=yes
 PrivateDevices=yes
 PrivateNetwork=yes
 PrivateUsers=no
-ProtectKernelTunables=yes
-ProtectKernelModules=yes
 ProtectControlGroups=yes
-MemoryDenyWriteExecute=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
 SystemCallFilter=@default @file-system @basic-io @system-service
+Type=oneshot

--- a/system/gromox-cleaner.service
+++ b/system/gromox-cleaner.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Gromox mailbox cleaner
+Requisite=gromox-http.service
+After=gromox-http.service
 
 [Service]
 # Fallback if EnvironmentFile hasn't got any value


### PR DESCRIPTION
Just read it again..  EnvironmentFile wins over Environment so that would fit.
ref:
https://manpages.debian.org/bookworm/systemd/systemd.exec.5.en.html#ENVIRONMENT_VARIABLES_IN_SPAWNED_PROCESSES

And all because i can see people wanting to change that and not by doing something like `systemctl edit gromox-cleaner.service`

