### PR TITLE
gromox-cleaner.service: fix date-var

### DIFF
--- a/system/gromox-cleaner.service
+++ b/system/gromox-cleaner.service
@@ -7,7 +7,7 @@ After=gromox-http.service
 # Fallback if EnvironmentFile hasn't got any value
 Environment=softdelete_purgetime=30d
 EnvironmentFile=/etc/gromox/gromox.cfg
-ExecStart=/usr/sbin/gromox-mbop foreach.here.mb ( purge-softdelete -d ${PURGETIME} -r / ) ( purge-datafiles )
+ExecStart=/usr/sbin/gromox-mbop foreach.here.mb ( purge-softdelete -d ${softdelete_purgetime} -r / ) ( purge-datafiles )
 MemoryDenyWriteExecute=yes
 PrivateDevices=yes
 PrivateNetwork=yes


### PR DESCRIPTION
And i just seen that this filter won't work either unless you probably have multiple servers running?

I can't get any of those working with a single node. `foreach.here.mb`/`foreach.mb.here`/`foreach.local.mb`/`foreach.mb.local` and it seems that isn't because of the repo:
```
S  | Name               | Type    | Version                     | Arch   | Repository
---+--------------------+---------+-----------------------------+--------+--------------------
i+ | gromox             | package | 2.38.48.76c3920-lp156.12.1  | x86_64 | grommunio
v  | gromox             | package | 2.38.48.g76c3920-lp156.42.1 | x86_64 | grommunio-community
v  | gromox             | package | 2.38.48.x76c3920-lp156.14.1 | x86_64 | grommunio-devel
```

