### PR TITLE
github-action: replace '-j$(cat ...)' with MAKEFLAG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,11 @@ on:
 
 jobs:
   build:
-    runs-on:
-      - ubuntu-24.04
-      - ubuntu-22.04
+    #runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ ubuntu-22.04 ]
     steps:
     - name: install-deps
       uses: awalsh128/cache-apt-pkgs-action@latest
@@ -30,7 +32,7 @@ jobs:
       with:
         repository: jengelh/libHX
         path: libHX
-    - name: cpucores
+    - name: cpucores-and-stuff
       run: |
         echo "lspcu-all: $(lscpu -a -p |grep -c -v '^#')"
         echo "lspcu-online: $(lscpu -b -p |grep -c -v '^#')"
@@ -38,6 +40,7 @@ jobs:
         echo "nproc: $(nproc)"
         echo "nproc-all: $(nproc --all)"
         echo "proc-cpuinfo: $(grep -c '^processor' /proc/cpuinfo)"
+        echo "MAKEFLAGS: -j$(nproc)"
         echo "MAKEFLAGS-x-2: -j$(($(nproc)*2))"
     - name: buildall
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,23 @@ jobs:
       with:
         repository: jengelh/libHX
         path: libHX
+    - name: cpucores
+      run: |
+        echo "lspcu-all: $(lscpu -a -p |grep -c -v '^#')"
+        echo "lspcu-online: $(lscpu -b -p |grep -c -v '^#')"
+        echo "lspcu-offline: $(lscpu -c -p |grep -c -v '^#')"
+        echo "nproc: $(nproc)"
+        echo "nproc-all: $(nproc --all)"
+        echo "proc-cpuinfo: $(grep -c '^processor' /proc/cpuinfo)"
+        echo "MAKEFLAGS-x-2: -j$(($(nproc)*2))"
     - name: buildall
       run: |
-        lscpu -b --online --parse | grep -v '^#' | wc -l >/tmp/ncpus
-        pushd vmime && cmake . -DVMIME_SENDMAIL_PATH:STRING="/usr/sbin/sendmail" -DVMIME_BUILD_SAMPLES:BOOL=OFF -DVMIME_HAVE_TLS_SUPPORT:BOOL=ON -DVMIME_BUILD_STATIC_LIBRARY:BOOL=OFF && make "-j$(cat /tmp/ncpus)" && sudo make install && popd
-        pushd libHX && ./qconf && make "-j$(cat /tmp/ncpus)" && sudo make install && popd
+        #export MAKEFLAGS="-j$(($(nproc)*2))"
+        export MAKEFLAGS="-j$(nproc)"
+        echo "MAKEFLAGS: $MAKEFLAGS"
+        pushd vmime && cmake . -DVMIME_SENDMAIL_PATH:STRING="/usr/sbin/sendmail" -DVMIME_BUILD_SAMPLES:BOOL=OFF -DVMIME_HAVE_TLS_SUPPORT:BOOL=ON -DVMIME_BUILD_STATIC_LIBRARY:BOOL=OFF && make && sudo make install && popd
+        pushd libHX && ./qconf && make && sudo make install && popd
         ./qconf
-        LD_LIBRARY_PATH=/usr/local/lib make "-j$(cat /tmp/ncpus)"
+        LD_LIBRARY_PATH=/usr/local/lib make
         LD_LIBRARY_PATH=/usr/local/lib make install DESTDIR="$PWD/rt" && rm -Rf rt
         make distclean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - ubuntu-24.04
+      - ubuntu-22.04
     steps:
     - name: install-deps
       uses: awalsh128/cache-apt-pkgs-action@latest


### PR DESCRIPTION
the job 'cpucores' is just to see if there is a difference but i guess it won't 🙈 
> https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories

then i tried to run it with 24.04(because of those notices/warnings) but either i'm having no luck or did something wrong. anyhow, it looks like libHX has a problem with `runs-on: ubuntu-24.04`.
