### PR TITLE
gromox-cleaner.service

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,10 +1,15 @@
-Snapshot 2.38.37
+Snapshot 2.38.76
 ================
 
 Fixes:
 
 * midb: resolve protocol mismatches with imap, pop3; resolves rejection of
   IMAP CREATE, POP3 PASS commands
+* midb: synchronize "Answered", "Forwarded" and "Flagged" flags between
+  MAPI and midb
+* midb: pass message flag modification notifications
+  (answered/forwarded/flagged/read/etc.) to imapd
+
 
 Enhancements:
 

--- a/system/gromox-cleaner.service
+++ b/system/gromox-cleaner.service
@@ -4,7 +4,7 @@ Requisite=gromox-http.service
 After=gromox-http.service
 
 [Service]
-# Fallback if EnvironmentFile hasn't got any value
+# Fallback if EnvironmentFile hasn't got any value.
 Environment=softdelete_purgetime="30d" cleaner_here=
 EnvironmentFile=/etc/gromox/gromox.cfg
 ExecStart=/usr/sbin/gromox-mbop foreach.mb"${cleaner_here}" purge-softdelete -t "${softdelete_purgetime}" -r /

--- a/system/gromox-cleaner.service
+++ b/system/gromox-cleaner.service
@@ -5,12 +5,13 @@ After=gromox-http.service
 
 [Service]
 # Fallback if EnvironmentFile hasn't got any value
-Environment=softdelete_purgetime=30d
+Environment=softdelete_purgetime="30d" cleaner_here=
 EnvironmentFile=/etc/gromox/gromox.cfg
-ExecStart=/usr/sbin/gromox-mbop foreach.here.mb ( purge-softdelete -d ${softdelete_purgetime} -r / ) ( purge-datafiles )
+ExecStart=/usr/sbin/gromox-mbop foreach.mb"${cleaner_here}" purge-softdelete -t "${softdelete_purgetime}" -r /
+ExecStart=/usr/sbin/gromox-mbop foreach.mb"${cleaner_here}" purge-datafiles
 MemoryDenyWriteExecute=yes
 PrivateDevices=yes
-PrivateNetwork=yes
+PrivateNetwork=no
 PrivateUsers=no
 ProtectControlGroups=yes
 ProtectKernelModules=yes


### PR DESCRIPTION
gromox-cleaner: fixes
* disable PrivateNetwork
* split concatenation to two ExecStart='s
* As .here isn't working w/o distributed setup disable it by default
  The option you will have to set in the config will be
  /etc/gromox/gromox.cfg:cleaner_here=.here
  which isn't pretty.
  .here should work on Servers w/ an empty result in
  `grommunio-admin config server` aswell as we are ALWAYS ".here".