### PR TITLE
mda: never override any already queued messages

### DIFF
--- a/mda/message_enqueue.cpp
+++ b/mda/message_enqueue.cpp
@@ -214,7 +214,7 @@ BOOL message_enqueue_try_save_mess(FLUSH_ENTITY *pentity)
 	}
 	uint64_t mess_len = 0;
 	if (NULL == pentity->pflusher->flush_ptr) {
-		fp = fopen(name.c_str(), "w");
+		fp = fopen(name.c_str(), "wx");
 		/* check if the file is created successfully */
 		if (fp == nullptr)
 			return FALSE;


### PR DESCRIPTION
The flush id handling seems to be highly fragile for race conditions. This commit makes the fopen fail if a mess file does already exist (i.e. the user moved files from `save/` to `mess/`) and **not** override it silently.
