### PR TITLE
tools/e2g.ps1: allow pubkey usage via pageant

### DIFF
--- a/tools/exchange2grommunio.ps1
+++ b/tools/exchange2grommunio.ps1
@@ -308,16 +308,18 @@ $PLINKARGS = @(
 	if ($null -ne $Debug) {
 		'-v'
 	}
-		'-ssh'
-		'-agent'
 	if ($null -ne $LinuxUserPWD) {
 		'-noagent'
 		'-pw'
 		"$LinuxUserPWD"
-	} elseif ($null -eq $UsePageant) {
-		'-i'
-		"$LinuxUserSSHKey"
+	} else {
+		'-agent'
+		if ($null -eq $UsePageant) {
+			'-i'
+			"$LinuxUserSSHKey"
+		}
 	}
+		'-ssh'
 		'-batch'
 		"$LinuxUser@$GrommunioServer"
 )


### PR DESCRIPTION
  * MailboxExportRequest: Use $MBX.Alias for safer handling.
  * Add Information how to use a persistent mount via fstab.
  * Use full cmdlet names rather than shorthands
  * Add Information on how to use gromox-mbop to clean any data from previous import tests.
  * create a mbx-exp-req/mailbox with extended details if something went wrong
  * create import.log/mailbox with the output of e2ghelper
  * implement pubkey authentication w/ optional passphrase via pageant
  * ....


@WalterHof o/