### PR TITLE
doc/istore - document gromox.cfg:istore_standalone

### DIFF
--- a/doc/exmdb_provider.4gx
+++ b/doc/exmdb_provider.4gx
@@ -4,12 +4,19 @@
 .SH Name
 exmdb_provider \(em Gromox Information Store
 .SH Description
-exmdb_provider is a component for http(8gx). It offers a plethora of
-low-level functions (124 of them) for operating on mailbox stores. This
-functionality is also exposed by way of a Gromox-specific network protocol on
-port 5000. The aforementioned RPC functions transparently operate over the
-network and may connect to a remote exmdb instance. In other words, this component contains
-a process-local function API, a network client, and a network server.
+exmdb_provider is the mailbox engine. It offers a plethora of stateless
+low-level functions (124 of them) for operating on mailbox stores. The
+functionality of the engine is exposed by way of a Gromox-specific network
+protocol on port 5000.
+.PP
+exmdb_provider is built as a shared library and can run in either the http(8gx)
+or istore(8gx) processes, depending on the gromox.cfg:istore_standalone config
+directive.
+.PP
+The shared library contributes an exmdb_client API, which will transparently
+pick either a local or a remote procedure call depending on whether the mailbox
+is served by the same process or not.
+.PP
 .SH Configuration directives (gromox.cfg)
 The following directives are recognized when they appear in
 /etc/gromox/gromox.cfg.

--- a/doc/http.8gx
+++ b/doc/http.8gx
@@ -75,6 +75,14 @@ custom header to convey the actual client address, Gromox can pick this up for
 its own reporting, which in turn is useful for e.g. fail2ban setups.
 .br
 Default: (empty)
+.TP
+\fBistore_standalone\fP
+This directive serves as a mutual exclusion device between http(8gx) and
+istore(8gx) and controls which one of the two is in charge of running the
+mailbox engine. If this is set to no, http will be the one and istore(8gx) has
+no function.
+.br
+Default: \fIno\fP
 .SH Configuration directives (http.cfg)
 The following directives are recognized when reading from /etc/gromox/http.cfg,
 or when the \fB\-c\fP option is used to specify a custom file:

--- a/doc/istore.8gx
+++ b/doc/istore.8gx
@@ -63,6 +63,14 @@ Maximum verbosity of logging. 1=crit, 2=error, 3=warn, 4=notice, 5=info, 6=debug
 .br
 Default: \fI4\fP (notice)
 .TP
+\fBistore_standalone\fP
+This directive serves as a mutual exclusion device between http(8gx) and
+istore(8gx) and controls which one of the two will execute the mailbox engine.
+If and only if this is set to yes will istore be able to startup, while http
+will disable the engine on its startup.
+.br
+Default: \fIno\fP
+.TP
 \fBrunning_identity\fP
 An unprivileged user account to switch the process to after startup.
 To inhibit the switch, assign the empty value.


### PR DESCRIPTION
it seems this has been forgotten.

and i only learned about it [just now](https://community.grommunio.com/d/2394-grommunio-on-ubuntu-2404-gromox-istore-vs-gromox-http-services) :p
