### PR TITLE
PHP-MAPI: Refactor detection of OPcache-module, support PHP8.5.

### DIFF
--- a/php_mapi/mapi.cpp
+++ b/php_mapi/mapi.cpp
@@ -482,11 +482,43 @@ static PHP_MSHUTDOWN_FUNCTION(mapi)
 
 static PHP_RINIT_FUNCTION(mapi)
 {
-	zstrplus str_opcache(zend_string_init(ZEND_STRL("zend opcache"), 0));
-	if (zend_hash_exists(&module_registry, str_opcache.get())) {
-		php_error_docref(nullptr, E_ERROR, "mapi: MAPI cannot execute while opcache is present. You must deactivate opcache in PHP (`phpdismod` command on some systems), or remove opcache entirely with the package manager. <https://docs.grommunio.com/kb/php.html>");
-		return FAILURE;
-	}
+        zstrplus str_opcache(zend_string_init(ZEND_STRL("zend opcache"), 0));
+        const char sz_fname[] = "opcache_get_configuration";
+        zstrplus zstr_fname(zend_string_init(ZEND_STRL(sz_fname), 0));
+        
+        if (zend_hash_exists(&module_registry, str_opcache.get()) ) {
+                bool b_opcache = true;
+                if (zend_hash_str_exists(CG(function_table), sz_fname, sizeof(sz_fname) - 1)) {
+                        /* look up directive['opcache.x'] */
+                        zval zfunc, zconfig;
+                        ZVAL_STR(&zfunc, zstr_fname.get());
+                        if (call_user_function(EG(function_table), NULL, &zfunc, &zconfig, 0, NULL) == SUCCESS) {
+                                const char sz_directives[] = "directives";
+                                zval *pdirectives = zend_hash_str_find(Z_ARRVAL(zconfig), sz_directives, sizeof(sz_directives) - 1);
+                                if (pdirectives && Z_TYPE_P(pdirectives) == IS_ARRAY) {
+                                        /* look up directive['opcache.enable'] */
+                                        const char sz_varname[] = "opcache.enable";
+                                        zval *penabled = zend_hash_str_find(Z_ARRVAL_P(pdirectives), sz_varname, sizeof(sz_varname) - 1);
+                                        if (penabled)
+                                                b_opcache = zval_get_long(penabled);
+                                        if (b_opcache && sapi_module.name != nullptr && strcasecmp(sapi_module.name, "cli") == 0){
+                                                /* look up directive['opcache.enable_cli */
+                                                const char sz_varname[] = "opcache.enable_cli";
+                                                zval *penabled = zend_hash_str_find(Z_ARRVAL_P(pdirectives), sz_varname, sizeof(sz_varname) - 1);
+                                        if (penabled)
+                                                b_opcache = zval_get_long(penabled); 
+                                        }
+                                }
+                                zval_ptr_dtor(&zconfig);
+                       }
+                }
+                if (b_opcache) {
+                        php_error_docref(nullptr, E_ERROR, "mapi: MAPI cannot execute while opcache is present and enabled. "
+                        "You must deactivate opcache in PHP (opcache.enable=0 or `phpdismod` command on some systems), "
+                        "or remove opcache entirely with the package manager. <https://docs.grommunio.com/kb/php.html>");
+                        return FAILURE;
+                }
+        }
 
 	zstrplus str_server(zend_string_init(ZEND_STRL("_SERVER"), 0));
 	zstrplus str_user(zend_string_init(ZEND_STRL("REMOTE_USER"), 0));


### PR DESCRIPTION
As things stand, stable operation of PHP_MAPI cannot be guaranteed with Zend OPcache-extension active. Thus, loading of PHP-MAPI is actively aborted when an opcache-module-signature is detected.
This change allows loading of PHP-MAPI despite present OPcache module, provided that OPcache is deactivated by configuration (opcache.enable=0, opcache.enable_cli=0). This possibility will be necessary latest when supporting PHP 8.5, as here the Zend OPcache-extension became a compiletime-module and therefor is always present. Using the` opcache.enable` option should be sufficiently safe, as opcache-deactivation is possible at runtime, whereas (re-)activation is not.

I'm currently running grommunio-sync, grommunio-web & gromox-timer with PHP8.5-FPM and PHP8.5-CLI. 
Sofar, no major issues have been seen.