### PR TITLE
Partially revert d73605c (late loading) for gromox-mbop

### DIFF
--- a/tools/mbop_main.cpp
+++ b/tools/mbop_main.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// SPDX-FileCopyrightText: 2022–2026 grommunio GmbH
+// SPDX-FileCopyrightText: 2022–2025 grommunio GmbH
 // This file is part of Gromox.
 #include <cerrno>
 #include <climits>
@@ -19,6 +19,7 @@
 #include <gromox/fileio.h>
 #include <gromox/freebusy.hpp>
 #include <gromox/mapidefs.h>
+#include <gromox/mysql_adaptor.hpp>
 #include <gromox/process.hpp>
 #include <gromox/svc_loader.hpp>
 #include <gromox/util.hpp>
@@ -492,6 +493,10 @@ static int single_user_wrap(int argc, char **argv)
 	return ret;
 }
 
+static constexpr generic_module g_dfl_svc_plugins[] = {
+	{"libgxs_mysql_adaptor.so", SVC_mysql_adaptor},
+};
+
 int main(int argc, char **argv)
 {
 	setvbuf(stdout, nullptr, _IOLBF, 0);
@@ -510,7 +515,7 @@ int main(int argc, char **argv)
 	argv = result.uarg;
 	if (argc == 0)
 		return global::help();
-	service_init({nullptr, {}, 2});
+	service_init({nullptr, g_dfl_svc_plugins, 2});
 	auto cl_1 = HX::make_scope_exit(service_stop);
 	if (service_run() != 0) {
 		fprintf(stderr, "service_run: failed\n");


### PR DESCRIPTION
Late loading of libgxs_mysql_adaptor in gromox-mbop is causing deadlocks in `mbop_userlist() ... g_sqlconn_pool.get_wait();`.
Revert to early loading.

Fixes #219