### PR TITLE
lib: fix deadlock in log to stderr

### DIFF
--- a/lib/string.cpp
+++ b/lib/string.cpp
@@ -784,8 +784,12 @@ void mlog_init(const char *ident, const char *filename, unsigned int max_level,
 	if (filename == nullptr || *filename == '\0' || strcmp(filename, "-") == 0) {
 		if (isatty(STDERR_FILENO))
 			mode = OM_STDERR_COLORS;
-		else if (getppid() == 1 && getenv("JOURNAL_STREAM") != nullptr)
-			mode = OM_SYSLOG;
+		else {
+			if (getppid() == 1 && getenv("JOURNAL_STREAM") != nullptr)
+				mode = OM_SYSLOG;
+			else
+				mode = OM_STDERR;
+		}
 	} else if (strcmp(filename, "syslog") == 0) {
 		mode = OM_SYSLOG;
 	}


### PR DESCRIPTION
[Commit 8ed9a6d lib: restore ability to log to file](https://github.com/grommunio/gromox/commit/8ed9a6d1dbe14cfe16bfb1398195decfc4baf2ca) 
successfully fixed log-target 'file', but breaks logging to  tty-targets or /dev/null

` gromox-export -u test@bostkastl.de --mail 44565049  2>/dev/null  |  rspamc $verb`
\<deadlock>

```
PID: 1258810 (gromox-export)
           UID: 0 (root)
           GID: 0 (root)
        Signal: 3 (QUIT)
     Timestamp: Mon 2026-03-16 21:58:33 CET (11h ago)
  Command Line: gromox-export -u test@bostkastl.de --mail 44565049
    Executable: /usr/sbin/gromox-export
 Control Group: /system.slice/ssh.service
          Unit: ssh.service
         Slice: system.slice
       Boot ID: 2c5817fb1bb24515a2976db9b62beb9d
    Machine ID: 1468887840b44e9ca32f497f79aeac52
      Hostname: oel.filter.is
       Storage: /var/lib/systemd/coredump/core.gromox-export.0.2c5817fb1bb24515a2976db9b62beb9d.1258810.1773694713000000.zst (present)
  Size on Disk: 367.6K
       Message: Process 1258810 (gromox-export) of user 999 dumped core.

                Module libzstd.so.1 from deb libzstd-1.5.7+dfsg-1.amd64
                Module libgcc_s.so.1 from deb gcc-14-14.2.0-19.amd64
                Module libstdc++.so.6 from deb gcc-14-14.2.0-19.amd64
                Module libmariadb.so.3 from deb mariadb-1:11.8.6-0+deb13u1.amd64
                Stack trace of thread 1258810:
                #0  0x00007fc8a4a9be9b n/a (libc.so.6 + 0x8fe9b)
                #1  0x00007fc8a4aa1f72 pthread_mutex_lock (libc.so.6 + 0x95f72)
                #2  0x00007fc8a51cca8d _ZL20__gthread_mutex_lockP15pthread_mutex_t (libgromox_common.so.0 + 0x24a8d)
                #3  0x00007fc8a51ccade _ZNSt5mutex4lockEv (libgromox_common.so.0 + 0x24ade)
                #4  0x00007fc8a51ccdfa _ZNSt10lock_guardISt5mutexEC2ERS0_ (libgromox_common.so.0 + 0x24dfa)
                #5  0x00007fc8a51f0281 _ZN6gromox4mlogEjPKcz (libgromox_common.so.0 + 0x48281)
                #6  0x00007fc8a51effa4 _ZN6gromox9mlog_initEPKcS1_jS1_ (libgromox_common.so.0 + 0x47fa4)
                #7  0x000055af86e1edda main (/usr/sbin/gromox-export + 0x9dda)
                #8  0x00007fc8a4a35ca8 n/a (libc.so.6 + 0x29ca8)
                #9  0x00007fc8a4a35d65 __libc_start_main (libc.so.6 + 0x29d65)
                #10 0x000055af86e1b8a1 _start (/usr/sbin/gromox-export + 0x68a1)
                ELF object binary architecture: AMD x86-64

```