### PR TITLE
ews: fix public folder access denied due to get_mbox_perm gate

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -3211,10 +3211,9 @@ uint32_t EWSContext::permissions(const std::string& maildir, uint64_t folderId) 
 	if (maildir == m_auth_info.maildir)
 		return 0xFFFFFFFF;
 	uint32_t permissions = 0;
-	if (!m_plugin.exmdb.get_mbox_perm(maildir.c_str(),
-	    m_auth_info.username, &permissions))
-		return 0;
-	if (permissions & frightsGromoxStoreOwner)
+	if (m_plugin.exmdb.get_mbox_perm(maildir.c_str(),
+	    m_auth_info.username, &permissions) &&
+	    (permissions & frightsGromoxStoreOwner))
 		return 0xFFFFFFFF;
 	if (!m_plugin.exmdb.get_folder_perm(maildir.c_str(), folderId,
 	    m_auth_info.username, &permissions))


### PR DESCRIPTION
Public folders are inaccessible via EWS (used by macOS Outlook) because EWSContext::permissions() calls get_mbox_perm() as a gate before checking folder-level ACLs, but get_mbox_perm() explicitly returns FALSE for public stores (by design — the EMSMDB/ROP path never calls it for public stores). The EWS code treated that FALSE as "no permissions" and returned 0, causing every subsequent frightsVisible/frightsReadAny check to fail with AccessDenied before get_folder_perm() was ever reached. This fix restructures the check so that get_mbox_perm() is only used for its intended purpose — the store-owner fast path on private stores — and all other cases (including public stores) fall through to get_folder_perm(), which correctly resolves permissions through the full ACL chain (explicit user entry → mailing list membership → "default" entry → CONFIG_ID_DEFAULT_PERMISSION), matching the behavior that the ROP path already provides to Windows Outlook.