### PR TITLE
http: release parked HPM contexts on unexpected input

### DIFF
--- a/exch/http/hpm_processor.cpp
+++ b/exch/http/hpm_processor.cpp
@@ -123,20 +123,17 @@ static void hpm_processor_wakeup_context(unsigned int context_id)
 {
 	auto phttp = static_cast<HTTP_CONTEXT *>(http_parser_get_contexts_list()[context_id]);
 	/*
-	 * Latch the wakeup *before* inspecting sched_stat. If the context is
-	 * mid-park (its plugin's retr() already returned HPM_RETRIEVE_WAIT, but
-	 * the worker has not set sched_stat to hsched_stat::wait yet), the
-	 * contexts_pool_signal() below is a no-op and the wakeup would be
-	 * lost – the context would then idle forever with an undelivered
-	 * response and never release its context_num slot. The wrrep parking
-	 * path consumes this latch (exchange) and re-polls instead of
-	 * sleeping. Writing the latch before reading sched_stat (and the park
-	 * path writing sched_stat before reading the latch) ensures at least
-	 * one side observes the other.
+	 * Latch wakeups that arrive while a context is not yet parked. If it is
+	 * already in hsched_stat::wait, signal it directly and do not leave the
+	 * latch set; otherwise the normal wakeup is consumed again when the
+	 * context tries to park after writing the response chunk.
 	 */
-	phttp->hpm_wakeup_pending = true;
-	if (phttp->sched_stat != hsched_stat::wait)
-		return;
+	if (phttp->sched_stat != hsched_stat::wait) {
+		phttp->hpm_wakeup_pending = true;
+		if (phttp->sched_stat != hsched_stat::wait)
+			return;
+	}
+	phttp->hpm_wakeup_pending = false;
 	phttp->sched_stat = hsched_stat::wrrep;
 	contexts_pool_signal(phttp);
 }

--- a/exch/http/http_parser.cpp
+++ b/exch/http/http_parser.cpp
@@ -2216,8 +2216,17 @@ tproc_status http_parser::wait(http_context *pcontext)
 		 * and gromox-http rejects all new connections until restarted.
 		 */
 		char tmp_buff;
-		if (recv(pcontext->connection.sockd, &tmp_buff,
-		    sizeof(tmp_buff), MSG_PEEK) == 0) {
+		auto ret = recv(pcontext->connection.sockd, &tmp_buff,
+		           sizeof(tmp_buff), MSG_PEEK);
+		if (ret == 0) {
+			pcontext->log(LV_DEBUG, "connection lost (hpm wait)");
+			return tproc_status::runoff;
+		}
+		if (ret > 0) {
+			pcontext->log(LV_DEBUG, "unexpected input while parked (hpm wait)");
+			return tproc_status::runoff;
+		}
+		if (errno != EAGAIN && errno != EWOULDBLOCK) {
 			pcontext->log(LV_DEBUG, "connection lost (hpm wait)");
 			return tproc_status::runoff;
 		}


### PR DESCRIPTION
When an HPM context is parked, `http_parser::wait` currently only treats
`recv(MSG_PEEK) == 0` as a lost connection. In an Outlook/EWS StreamingEvents
scenario, stale parked connections were observed in `CLOSE-WAIT` while bytes
were still queued in `Recv-Q`. In that state `recv(MSG_PEEK)` returns a positive
value, so the parked context is not released and continues to occupy an HTTP
context slot.

After enough such contexts accumulate, gromox-http can reject or stall new EWS
requests until the service is restarted.

This change treats positive `MSG_PEEK` results while parked as unexpected input
and runs the context off. It also clears `hpm_wakeup_pending` when a context is
directly woken from `hsched_stat::wait`, so the wakeup latch is not consumed
again during the next park attempt.

Observed with Outlook Classic for Mac EWS sync:

- before the patch: growing `CLOSE-WAIT` count on gromox-http ports and Outlook
  stuck while determining changes;
- after the patch: repeated Outlook Mac/Windows sync cycles without new
  `CLOSE-WAIT` buildup on the gromox-http listener ports and without HTTP 503
  saturation.

