### PR TITLE
http: clear the HPM wakeup latch on successful delivery

### DIFF
--- a/exch/http/hpm_processor.cpp
+++ b/exch/http/hpm_processor.cpp
@@ -137,6 +137,17 @@ static void hpm_processor_wakeup_context(unsigned int context_id)
 	phttp->hpm_wakeup_pending = true;
 	if (phttp->sched_stat != hsched_stat::wait)
 		return;
+	/*
+	 * This wakeup is being delivered through the normal channel right
+	 * below, so clear the latch. Otherwise it stays set (nothing else
+	 * clears it) and gets misread by wrrep_nobuf() as a *new* wakeup
+	 * having raced in during the run that is about to start, forcing an
+	 * immediate re-loop instead of an actual park on every single cycle
+	 * from here on — i.e. a permanent busy loop for any context that
+	 * ever received one wakeup (every EWS streaming/emsmdb-notification
+	 * context, via its own heartbeat timer).
+	 */
+	phttp->hpm_wakeup_pending = false;
 	phttp->sched_stat = hsched_stat::wrrep;
 	contexts_pool_signal(phttp);
 }


### PR DESCRIPTION
## Summary

Root-caused a load-average ~50 / OOM incident on a production box: any EWS streaming (`GetStreamingEvents`) or MH-emsmdb notification context, the moment it received its *first* wakeup, busy-looped forever - writing a new response chunk every cycle with no delay. nginx (proxying the connection) went from ~1.5GB to 7GB+ RSS in under 90s, driving load average to ~40 and swap to full, one instance triggering the kernel OOM killer.

While chasing this we found and cherry-picked (or independently reimplemented) several related upstream fixes for the same general area (HPM wakeup race, streaming event backlog capping) - it turned out master already carries equivalent fixes for all of those, so this PR is down to the one genuinely missing piece.

## `http: clear the HPM wakeup latch on successful delivery`

`hpm_wakeup_pending` is set unconditionally by `hpm_processor_wakeup_context()` before checking `sched_stat`, but was only ever cleared on the two paths in `http_parser.cpp` (`wrrep_nobuf()`'s `WAIT` branch, and one other spot) - never in `hpm_processor_wakeup_context()` itself when the wakeup is delivered through the normal (`sched_stat == wait`) channel right there. That consuming check in `http_parser.cpp` runs right after the just-woken context finishes its cycle and tries to park again - by which point the latch is still set from the very wakeup that got it there, so it always reads true and forces an immediate re-loop instead of a real park.

Fix: clear the latch when it is actually consumed via the normal delivery path in `hpm_processor_wakeup_context()`, leaving it set only for the genuine race window (wakeup arriving before `sched_stat` becomes `wait`) that the existing race-window handling in `http_parser.cpp` already covers.

## Testing

Running in production since 2026-07-08, through several EWS client reconnect cycles, with no recurrence of the busy-loop pattern.