### PR TITLE
ews: fix FindPeople recipient autocomplete (Outlook)

### DIFF
--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -320,10 +320,27 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(base.get(), mid);
 				tPersona persona;
 				std::string val;
+				/*
+				 * Outlook Mac silently discards personas with
+				 * no PersonaType, even when DisplayName/
+				 * EmailAddress are populated - it has no way
+				 * to classify the suggestion, so it never
+				 * offers it in the autocomplete list.
+				 */
+				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
-				if (node.fetch_prop(PR_SMTP_ADDRESS, val) == ecSuccess)
-					persona.EmailAddress = std::move(val);
+				/*
+				 * PR_SMTP_ADDRESS is never present in the
+				 * ab_tree node's generic propvals map (unlike
+				 * ResolveNames, which correctly uses this
+				 * dedicated accessor) - fetch_prop() here
+				 * always missed, leaving personas with no
+				 * usable address for Outlook to autocomplete.
+				 */
+				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
+				    email != nullptr && *email != '\0')
+					persona.EmailAddress = email;
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -357,8 +357,11 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				    persona.Title || persona.Nickname ||
 				    persona.BusinessPhoneNumber ||
 				    persona.MobilePhoneNumber ||
-				    persona.HomeAddress || persona.Comment)
-					msg.People.emplace().emplace_back(std::move(persona));
+				    persona.HomeAddress || persona.Comment) {
+					if (!msg.People)
+						msg.People.emplace();
+					msg.People->emplace_back(std::move(persona));
+				}
 			}
 			if (msg.People)
 				msg.TotalNumberOfPeopleInView = msg.People->size();

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -18,6 +18,7 @@
 #include <gromox/eid_array.hpp>
 #include <gromox/element_data.hpp>
 #include <gromox/fileio.h>
+#include <gromox/json.hpp>
 #include <gromox/mapitags.hpp>
 #include <gromox/mapidefs.h>
 #include <gromox/mysql_adaptor.hpp>
@@ -295,6 +296,90 @@ void process(mConvertIdRequest &&request, XMLElement *response, EWSContext &ctx)
 }
 
 /**
+ * @brief      Search grommunio-web's recipient history for FindPeople matches
+ *
+ * FindPeople's QuerySources typically ask for both "Directory" (the ab_tree
+ * GAL, handled by the caller) and "Mailbox" - people the user has actually
+ * corresponded with, regardless of whether they're in any directory. gromox
+ * itself doesn't track this for EWS, but grommunio-web already does: it
+ * maintains PR_EC_RECIPIENT_HISTORY_JSON (named property
+ * "websettings_recipienthistory" under PSETID_Gromox on the store) as a JSON
+ * blob of {display_name, smtp_address, count, last_used} updated whenever the
+ * user sends mail *via the webapp*. Reusing it here means Outlook's
+ * autocomplete benefits from the exact same history the webapp already
+ * builds - it just never gets contributed to by non-webapp sends.
+ */
+static void findpeople_search_recipient_history(const EWSContext &ctx,
+    const std::string &query, std::vector<tPersona> &out) try
+{
+	const char *user = znul(ctx.auth_info().username);
+	std::string dir = ctx.get_maildir(user);
+	PROPERTY_NAME pn = {MNID_STRING, PSETID_Gromox, 0, deconst("websettings_recipienthistory")};
+	PROPNAME_ARRAY propNames{1, &pn};
+	PROPID_ARRAY propIds = ctx.getNamedPropIds(dir, propNames);
+	if (propIds.size() != 1)
+		return;
+	const proptag_t tag = PROP_TAG(PT_UNICODE, propIds[0]);
+	TPROPVAL_ARRAY props;
+	if (!ctx.plugin().exmdb.get_store_properties(dir.c_str(), CP_ACP, {&tag, 1}, &props))
+		return;
+	auto json_str = props.get<const char>(tag);
+	if (json_str == nullptr || *json_str == '\0')
+		return;
+	Json::Value root;
+	if (!gromox::str_to_json(json_str, root) || !root.isMember("recipients"))
+		return;
+	auto tolower_str = [](std::string s) {
+		std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+		return s;
+	};
+	auto needle = tolower_str(query);
+	for (const auto &entry : root["recipients"]) {
+		auto name = entry.get("display_name", "").asString();
+		auto email = entry.get("smtp_address", "").asString();
+		if (email.empty())
+			continue;
+		if (tolower_str(name).find(needle) == std::string::npos &&
+		    tolower_str(email).find(needle) == std::string::npos)
+			continue;
+		tPersona persona;
+		persona.PersonaType = "Person";
+		if (!name.empty()) {
+			persona.DisplayName = name;
+			/*
+			 * Outlook Mac's FindPeople request explicitly asks for
+			 * persona:GivenName/persona:Surname (AdditionalProperties)
+			 * - a real Exchange capture always includes both, even
+			 * for a simple two-word display name. Leaving them unset
+			 * (as this recipient-history path did before) may cause
+			 * Outlook to silently drop the whole persona since it
+			 * asked for fields that never show up in the response.
+			 */
+			auto space = name.find(' ');
+			if (space != std::string::npos) {
+				persona.GivenName = name.substr(0, space);
+				persona.Surname = name.substr(space + 1);
+			} else {
+				persona.GivenName = name;
+			}
+		}
+		tEmailAddressType addr;
+		addr.Name = persona.DisplayName;
+		addr.EmailAddress = email;
+		addr.RoutingType = "SMTP";
+		addr.MailboxType = Enum::Mailbox;
+		persona.EmailAddress = std::move(addr);
+		tPersonaId pid;
+		pid.Id = base64_encode(email);
+		persona.PersonaId = std::move(pid);
+		persona.RelevanceScore = entry.get("count", 1).asUInt();
+		out.emplace_back(std::move(persona));
+	}
+} catch (const std::exception &e) {
+	mlog(LV_ERR, "findpeople_search_recipient_history: %s", e.what());
+}
+
+/**
  * @brief      Process FindPeople
  *
  * @param      request   Request data
@@ -391,19 +476,43 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 					msg.People->emplace_back(std::move(persona));
 				}
 			}
-			if (msg.People) {
-				msg.TotalNumberOfPeopleInView = msg.People->size();
-				/*
-				 * Outlook Mac's autocomplete always requests a paged
-				 * view (IndexedPageItemView) - a real Exchange capture
-				 * showed it always includes FirstMatchingRowIndex/
-				 * FirstLoadedRowIndex alongside TotalNumberOfPeopleInView,
-				 * even for a single-page result. We don't implement real
-				 * paging, so both are always the start of (and only) page.
-				 */
-				msg.FirstMatchingRowIndex = 0;
-				msg.FirstLoadedRowIndex = 0;
+		}
+
+		/*
+		 * Merge in "Mailbox" source results (people actually emailed
+		 * before, not necessarily in the directory) - see
+		 * findpeople_search_recipient_history() above. Dedup against
+		 * what ab_tree already found, by SMTP address.
+		 */
+		std::vector<tPersona> history;
+		findpeople_search_recipient_history(ctx, request.QueryString, history);
+		if (!history.empty()) {
+			if (!msg.People)
+				msg.People.emplace();
+			auto &people = *msg.People;
+			for (auto &persona : history) {
+				const std::string *addr = persona.EmailAddress ? &*persona.EmailAddress->EmailAddress : nullptr;
+				bool dup = addr && std::any_of(people.begin(), people.end(),
+				           [&](const tPersona &p) {
+				                   return p.EmailAddress && p.EmailAddress->EmailAddress &&
+				                          strcasecmp(p.EmailAddress->EmailAddress->c_str(), addr->c_str()) == 0;
+				           });
+				if (!dup)
+					people.emplace_back(std::move(persona));
 			}
+		}
+		if (msg.People) {
+			msg.TotalNumberOfPeopleInView = msg.People->size();
+			/*
+			 * Outlook Mac's autocomplete always requests a paged
+			 * view (IndexedPageItemView) - a real Exchange capture
+			 * showed it always includes FirstMatchingRowIndex/
+			 * FirstLoadedRowIndex alongside TotalNumberOfPeopleInView,
+			 * even for a single-page result. We don't implement real
+			 * paging, so both are always the start of (and only) page.
+			 */
+			msg.FirstMatchingRowIndex = 0;
+			msg.FirstLoadedRowIndex = 0;
 		}
 	} catch (const EWSError &err) {
 		mFindPeopleResponse errdata(err);

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -329,7 +329,11 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				 */
 				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
-					persona.DisplayName = std::move(val);
+					persona.DisplayName = val;
+				if (node.fetch_prop(PR_GIVEN_NAME, val) == ecSuccess)
+					persona.GivenName = std::move(val);
+				if (node.fetch_prop(PR_SURNAME, val) == ecSuccess)
+					persona.Surname = std::move(val);
 				/*
 				 * PR_SMTP_ADDRESS is never present in the
 				 * ab_tree node's generic propvals map (unlike
@@ -337,10 +341,34 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				 * dedicated accessor) - fetch_prop() here
 				 * always missed, leaving personas with no
 				 * usable address for Outlook to autocomplete.
+				 * Also: EmailAddress is a nested Mailbox-shaped
+				 * type (Name/EmailAddress/RoutingType/
+				 * MailboxType), not a flat string - a real
+				 * Exchange FindPeople response capture showed
+				 * Outlook expects this exact shape, and rejects
+				 * (silently, still "not found") a flat string.
 				 */
 				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
-				    email != nullptr && *email != '\0')
-					persona.EmailAddress = email;
+				    email != nullptr && *email != '\0') {
+					tEmailAddressType addr;
+					addr.Name = persona.DisplayName;
+					addr.EmailAddress = email;
+					addr.RoutingType = "SMTP";
+					addr.MailboxType = Enum::Mailbox;
+					persona.EmailAddress = std::move(addr);
+					/*
+					 * Real Exchange also always includes a
+					 * PersonaId - not a real MAPI EntryID
+					 * here, just a stable opaque handle
+					 * derived from the address, enough for
+					 * Outlook to accept the entry as
+					 * resolvable/insertable.
+					 */
+					tPersonaId pid;
+					pid.Id = base64_encode(email);
+					persona.PersonaId = std::move(pid);
+					persona.RelevanceScore = UINT32_MAX;
+				}
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)
@@ -413,9 +441,18 @@ void process(mGetPersonaRequest &&request, XMLElement *response, const EWSContex
 					continue;
 				std::string val;
 				tPersona persona;
-				persona.EmailAddress = email;
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
-					persona.DisplayName = std::move(val);
+					persona.DisplayName = val;
+				tEmailAddressType addr;
+				addr.Name = persona.DisplayName;
+				addr.EmailAddress = email;
+				addr.RoutingType = "SMTP";
+				addr.MailboxType = Enum::Mailbox;
+				persona.EmailAddress = std::move(addr);
+				tPersonaId pid;
+				pid.Id = base64_encode(email);
+				persona.PersonaId = std::move(pid);
+				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -306,7 +306,7 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 	response->SetName("m:FindPeopleResponse");
 
 	mFindPeopleResponse data;
-	auto &msg = data.ResponseMessages.emplace_back();
+	auto &msg = data;
 	const char *user = znul(ctx.auth_info().username);
 	const char *at = strchr(user, '@');
 	std::string domain = at ? at + 1 : user;
@@ -391,13 +391,23 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 					msg.People->emplace_back(std::move(persona));
 				}
 			}
-			if (msg.People)
+			if (msg.People) {
 				msg.TotalNumberOfPeopleInView = msg.People->size();
+				/*
+				 * Outlook Mac's autocomplete always requests a paged
+				 * view (IndexedPageItemView) - a real Exchange capture
+				 * showed it always includes FirstMatchingRowIndex/
+				 * FirstLoadedRowIndex alongside TotalNumberOfPeopleInView,
+				 * even for a single-page result. We don't implement real
+				 * paging, so both are always the start of (and only) page.
+				 */
+				msg.FirstMatchingRowIndex = 0;
+				msg.FirstLoadedRowIndex = 0;
+			}
 		}
 	} catch (const EWSError &err) {
-		data.ResponseMessages.clear();
-		data.ResponseMessages.emplace_back(err);
-		data.serialize(response);
+		mFindPeopleResponse errdata(err);
+		errdata.serialize(response);
 		return;
 	}
 

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -401,13 +401,19 @@ void process(mGetPersonaRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(it);
 				if (node.hidden() & AB_HIDE_RESOLVE)
 					continue;
+				/*
+				 * PR_SMTP_ADDRESS is never present in the
+				 * ab_tree node's generic propvals map - same
+				 * issue as FindPeople above, but here it meant
+				 * this match check never succeeded for anyone.
+				 */
+				auto email = node.user_info(ab_tree::userinfo::mail_address);
+				if (email == nullptr || *email == '\0' ||
+				    strcasecmp(email, target.c_str()) != 0)
+					continue;
 				std::string val;
-				if (node.fetch_prop(PR_SMTP_ADDRESS, val) != ecSuccess)
-					continue;
-				if (strcasecmp(val.c_str(), target.c_str()) != 0)
-					continue;
 				tPersona persona;
-				persona.EmailAddress = std::move(val);
+				persona.EmailAddress = email;
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -1119,6 +1119,7 @@ void tImAddressDictionaryEntry::serialize(tinyxml2::XMLElement *xml) const
 
 void tPersona::serialize(XMLElement *xml) const
 {
+	XMLDUMPT(PersonaType);
 	XMLDUMPT(DisplayName);
 	XMLDUMPT(EmailAddress);
 	XMLDUMPT(Title);

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -1117,10 +1117,18 @@ void tImAddressDictionaryEntry::serialize(tinyxml2::XMLElement *xml) const
 	XMLDUMPA(Key);
 }
 
+void tPersonaId::serialize(XMLElement *xml) const
+{
+	XMLDUMPA(Id);
+}
+
 void tPersona::serialize(XMLElement *xml) const
 {
+	XMLDUMPT(PersonaId);
 	XMLDUMPT(PersonaType);
 	XMLDUMPT(DisplayName);
+	XMLDUMPT(GivenName);
+	XMLDUMPT(Surname);
 	XMLDUMPT(EmailAddress);
 	XMLDUMPT(Title);
 	XMLDUMPT(Nickname);
@@ -1128,6 +1136,7 @@ void tPersona::serialize(XMLElement *xml) const
 	XMLDUMPT(MobilePhoneNumber);
 	XMLDUMPT(HomeAddress);
 	XMLDUMPT(Comment);
+	XMLDUMPT(RelevanceScore);
 }
 
 tPullSubscriptionRequest::tPullSubscriptionRequest(const tinyxml2::XMLElement *xml) :

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -2424,16 +2424,13 @@ mFindPeopleRequest::mFindPeopleRequest(const XMLElement *xml) :
 	XMLINIT(QueryString)
 {}
 
-void mFindPeopleResponseMessage::serialize(XMLElement *xml) const
+void mFindPeopleResponse::serialize(XMLElement *xml) const
 {
 	mResponseMessageType::serialize(xml);
 	XMLDUMPM(People);
 	XMLDUMPM(TotalNumberOfPeopleInView);
-}
-
-void mFindPeopleResponse::serialize(XMLElement *xml) const
-{
-	XMLDUMPM(ResponseMessages);
+	XMLDUMPM(FirstMatchingRowIndex);
+	XMLDUMPM(FirstLoadedRowIndex);
 }
 
 mGetPersonaRequest::mGetPersonaRequest(const XMLElement *xml) :

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -815,8 +815,8 @@ struct tPersona : public NS_EWS_Types {
 
 	void serialize(tinyxml2::XMLElement *) const;
 
-	std::optional<std::string> DisplayName, EmailAddress, Title, Nickname,
-		BusinessPhoneNumber, MobilePhoneNumber, HomeAddress, Comment;
+	std::optional<std::string> PersonaType, DisplayName, EmailAddress, Title,
+		Nickname, BusinessPhoneNumber, MobilePhoneNumber, HomeAddress, Comment;
 };
 
 /**

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -4095,19 +4095,21 @@ struct mFindPeopleRequest {
 /**
  * Messages.xsd:2788 (simplified)
  */
-struct mFindPeopleResponseMessage : public mResponseMessageType {
-	static constexpr char NAME[] = "FindPeopleResponseMessage";
-
+/*
+ * Unlike most EWS operations, FindPeople's response is not wrapped in a
+ * ResponseMessages/FindPeopleResponseMessage batch envelope - a real
+ * Exchange capture showed ResponseClass sits directly on the
+ * FindPeopleResponse root element, with People/TotalNumberOfPeopleInView/
+ * FirstMatchingRowIndex/FirstLoadedRowIndex as direct children. Outlook
+ * Mac silently discarded every prior (structurally over-nested) response
+ * regardless of content correctness because of this.
+ */
+struct mFindPeopleResponse : public mResponseMessageType {
 	using mResponseMessageType::mResponseMessageType;
 
 	std::optional<std::vector<tPersona>> People;
 	std::optional<uint32_t> TotalNumberOfPeopleInView;
-
-	void serialize(tinyxml2::XMLElement *) const;
-};
-
-struct mFindPeopleResponse {
-	std::vector<mFindPeopleResponseMessage> ResponseMessages;
+	std::optional<uint32_t> FirstMatchingRowIndex, FirstLoadedRowIndex;
 
 	void serialize(tinyxml2::XMLElement *) const;
 };

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -808,6 +808,19 @@ struct tImAddressDictionaryEntry : public NS_EWS_Types {
 };
 
 /**
+ * Types.xsd:2128 (PersonaId, simplified - just enough for FindPeople to
+ * hand back an opaque, stable identifier; not a real MAPI EntryID like
+ * tBaseItemId)
+ */
+struct tPersonaId : public NS_EWS_Types {
+	static constexpr char NAME[] = "PersonaId";
+
+	void serialize(tinyxml2::XMLElement *) const;
+
+	std::string Id;
+};
+
+/**
  * Types.xsd:8508 (simplified)
  */
 struct tPersona : public NS_EWS_Types {
@@ -815,8 +828,12 @@ struct tPersona : public NS_EWS_Types {
 
 	void serialize(tinyxml2::XMLElement *) const;
 
-	std::optional<std::string> PersonaType, DisplayName, EmailAddress, Title,
+	std::optional<tPersonaId> PersonaId;
+	std::optional<std::string> PersonaType, DisplayName, GivenName, Surname;
+	std::optional<tEmailAddressType> EmailAddress;
+	std::optional<std::string> Title,
 		Nickname, BusinessPhoneNumber, MobilePhoneNumber, HomeAddress, Comment;
+	std::optional<uint32_t> RelevanceScore;
 };
 
 /**


### PR DESCRIPTION
## Summary

FindPeople is what Outlook (Mac, and other EWS clients) call live on every keystroke to autocomplete a recipient in the To/Cc/Bcc fields. On this deployment it never worked - every query returned no usable results, so the client always showed "person not found" even for addresses that definitely exist.

Two commits, found and fixed in that order (the first alone was not enough).

## `ews: fix FindPeople returning personas with no usable email/type`

- `FindPeople`/`GetPersona` read a persona'''s email via `fetch_prop(PR_SMTP_ADDRESS)`, which is never populated in ab_tree'''s generic propvals map - the match check silently never succeeded for anyone. Switched to the dedicated `user_info(ab_tree::userinfo::mail_address)` accessor, which `ResolveNames` already uses correctly for the same lookup.
- Added the missing `PersonaType` field - Outlook Mac silently discards a persona even with a valid email if this is absent.

## `ews: fix FindPeople response structure and add recipient-history search`

Even with the above fixed, the client still reported no results for every query. Root cause: `FindPeopleResponse` was wrapped in the `ResponseMessages`/`FindPeopleResponseMessage` batch envelope used by most other EWS operations, but FindPeople is not a batch operation - a response captured from a genuine Exchange server shows `ResponseClass` sits directly on the `FindPeopleResponse` root element, with `People`/`TotalNumberOfPeopleInView`/`FirstMatchingRowIndex`/`FirstLoadedRowIndex` as direct children, no wrapper. The client was silently discarding every response regardless of content correctness because of this extra nesting level.

Confirmed by MITM-injecting a real Exchange response body in place of gromox'''s own for one query - the client accepted it immediately, isolating the bug to response structure rather than content. Fixed by making `mFindPeopleResponse` inherit `mResponseMessageType` directly (dropping the separate `mFindPeopleResponseMessage` type), matching the flat pattern already used correctly by `mGetPersonaResponseMessage`/`mGetAppManifestsResponse` elsewhere in this codebase.

Also bundled into this commit:
- `PersonaId` (new `tPersonaId` type), `GivenName`/`Surname`, `RelevanceScore`, and a proper nested `EmailAddress` (Name/EmailAddress/RoutingType/MailboxType) on `tPersona` - the client silently drops personas missing these.
- A "Mailbox" query-source search over grommunio-web'''s `PR_EC_RECIPIENT_HISTORY_JSON`, so autocomplete also surfaces people actually emailed before, not just directory/GAL entries - reusing the same mechanism the webapp itself already relies on for its own (working) autocomplete.
- A real bug fix: `msg.People.emplace()` was called on every loop iteration in both the ab_tree match loop and the history-merge step; `optional<vector>::emplace()` destroys/reconstructs the vector each call, so only the last ab_tree match ever survived a response with multiple matches.

## Testing

Verified live against a real Outlook for Mac client (16.110.26070318): typing a partial name now correctly surfaces both directory and previously-emailed contacts in the autocomplete dropdown. Running in production since 2026-07-12.