### PR TITLE
mbop: add movemsg command

### DIFF
--- a/doc/gromox-mbop.8
+++ b/doc/gromox-mbop.8
@@ -62,6 +62,8 @@ get\-photo: retrieve user image from store and print to stdout
 get\-websettings, get\-websettings\-persistent, get\-websettings\-recipients:
 retrieve settings for grommunio-web
 .IP \(bu 4
+movemsg: move or copy a message between folders
+.IP \(bu 4
 ping: cause a mailbox's sqlite files to be opened
 .IP \(bu 4
 purge\-datafiles: remove orphaned attachments/content files from disk
@@ -350,6 +352,28 @@ a summary will be shown there.
 \fBget\-websettings\-recipients >\fP\fIautocomplete.json\fP
 .SS Description
 Reads various grommunio-web settings from the store and dumps it to stdout.
+.SH movemsg
+.SS Synopsis
+\fBmovemsg \-f\fP \fIfolder_spec\fP \fB\-t\fP \fIfolder_spec\fP
+[\fB\-\-copy\fP] \fImsgid\fP[\fB,\fP...]
+.SS Description
+Moves, or with \fB\-\-copy\fP, copies one or more messages from one folder to
+another within the same store.
+.PP
+The message IDs taken as arguments on the command-line should be
+of the GC-value form, i.e. as they appear in the SQLite database.
+(For details about GCV, see glossary.rst in the source distribution.)
+.SS Subcommand options
+.TP
+\fB-f\fP \fIfolder_spec\fP
+The source folder. See section "Folder specification" below for syntax
+details of \fIfolder_spec\fP.
+.TP
+\fB-t\fP \fIfolder_spec\fP
+The destination folder.
+.TP
+\fB\-\-copy\fP
+Copy the messages instead of moving them.
 .SH ping
 Causes the respective mailbox to be opened by the server. (Any request to the
 information storage server causes the respective mailbox to be opened; and ping

--- a/tools/mbop.cpp
+++ b/tools/mbop.cpp
@@ -4,6 +4,7 @@
 #include "mbop_foreach.cpp"
 #include "mbop_freebusy.cpp"
 #include "mbop_locale.cpp"
+#include "mbop_movemsg.cpp"
 #include "mbop_main.cpp"
 #include "mbop_purge.cpp"
 #include "mbop_walk.cpp"

--- a/tools/mbop.hpp
+++ b/tools/mbop.hpp
@@ -17,6 +17,7 @@ static constexpr int EXIT_PARAM = 2;
 
 namespace cgkreset { extern int main(int, char **); }
 namespace delmsg { extern int main(int, char **); }
+namespace movemsg { extern int main(int, char **); }
 namespace emptyfld { extern int main(int, char **); }
 namespace foreach_wrap { extern int main(int, char **); }
 namespace getfreebusy { extern int main(int, char **); }

--- a/tools/mbop_main.cpp
+++ b/tools/mbop_main.cpp
@@ -82,7 +82,7 @@ void command_overview()
 	fprintf(stderr, "Commands:\n\tcgkreset clear-photo clear-profile "
 		"clear-rwz delmsg echo-maildir echo-username emptyfld "
 		"freeze get-freebusy get-photo get-websettings "
-		"get-websettings-persistent get-websettings-recipients ping "
+		"get-websettings-persistent get-websettings-recipients movemsg ping "
 		"purge-datafiles purge-softdelete recalc-sizes set-locale "
 		"set-photo set-websettings set-websettings-persistent "
 		"set-websettings-recipients sync-midb thaw unload vacuum\n");
@@ -575,6 +575,8 @@ int cmd_parser(int argc, char **argv)
 	++g_command_num;
 	if (strcmp(argv[0], "delmsg") == 0)
 		return delmsg::main(argc, argv);
+	else if (strcmp(argv[0], "movemsg") == 0)
+		return movemsg::main(argc, argv);
 	else if (strcmp(argv[0], "emptyfld") == 0)
 		return emptyfld::main(argc, argv);
 	else if (strcmp(argv[0], "clear-photo") == 0)

--- a/tools/mbop_movemsg.cpp
+++ b/tools/mbop_movemsg.cpp
@@ -26,7 +26,7 @@ static constexpr HXoption g_options_table[] = {
 
 static int help()
 {
-	fprintf(stderr, "Usage: gromox-mbop -u a@b.de movemsg -f src_folder_id -t dst_folder_id message_id[,...]\n");
+	fprintf(stderr, "Usage: gromox-mbop -u a@b.de movemsg -f src_folder_id -t dst_folder_id message_id...\n");
 	return EXIT_PARAM;
 }
 

--- a/tools/mbop_movemsg.cpp
+++ b/tools/mbop_movemsg.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 grommunio GmbH
+// This file is part of Gromox.
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <libHX/option.h>
+#include <gromox/exmdb_client.hpp>
+#include <gromox/mapidefs.h>
+#include <gromox/rop_util.hpp>
+#include "genimport.hpp"
+#include "mbop.hpp"
+
+using namespace gromox;
+
+namespace movemsg {
+
+static constexpr HXoption g_options_table[] = {
+	{{}, 'f', HXTYPE_STRING, {}, {}, {}, 'f', "Source folder ID"},
+	{{}, 't', HXTYPE_STRING, {}, {}, {}, 't', "Destination folder ID"},
+	{"copy", 0, HXTYPE_NONE, {}, {}, {}, 'c', "Copy instead of move"},
+	MBOP_AUTOHELP,
+	HXOPT_TABLEEND,
+};
+
+static int help()
+{
+	fprintf(stderr, "Usage: gromox-mbop -u a@b.de movemsg -f src_folder_id -t dst_folder_id message_id[,...]\n");
+	return EXIT_PARAM;
+}
+
+int main(int argc, char **argv)
+{
+	bool g_copy = false;
+	const char *g_srcstr = nullptr, *g_dststr = nullptr;
+	eid_t g_srcfid{}, g_dstfid{};
+
+	HXopt6_auto_result result;
+	if (HX_getopt6(g_options_table, argc, argv, &result, HXOPT_USAGEONERR |
+	    HXOPT_ITER_OA) != HXOPT_ERR_SUCCESS || g_exit_after_optparse)
+		return EXIT_PARAM;
+	for (int i = 0; i < result.nopts; ++i) {
+		if (result.desc[i]->val == 'f')
+			g_srcstr = result.oarg[i];
+		else if (result.desc[i]->val == 't')
+			g_dststr = result.oarg[i];
+		else if (result.desc[i]->val == 'c')
+			g_copy = true;
+	}
+	if (g_srcstr != nullptr)
+		g_srcfid = gi_lookup_eid_any_way(g_storedir, g_srcstr);
+	if (g_dststr != nullptr)
+		g_dstfid = gi_lookup_eid_any_way(g_storedir, g_dststr);
+	if (rop_util_get_gc_value(g_srcfid) == 0 || rop_util_get_gc_value(g_dstfid) == 0)
+		return help();
+	std::vector<eid_t> eids;
+	for (int uidx = 0; uidx < result.nargs; ++uidx) {
+		eid_t eid{1, strtoul(result.uarg[uidx], nullptr, 0)};
+		if (eid == 0) {
+			mbop_fprintf(stderr, "Not recognized/found: \"%s\"\n", result.uarg[uidx]);
+			return EXIT_FAILURE;
+		}
+		eids.push_back(eid);
+	}
+	EID_ARRAY ea;
+	ea.count = eids.size();
+	ea.pids = eids.data();
+	BOOL partial = false;
+	if (!exmdb_client->movecopy_messages(g_storedir, CP_UTF8, false, nullptr,
+	    g_srcfid, g_dstfid, g_copy, &ea, &partial)) {
+		printf("RPC was rejected.\n");
+		return EXIT_FAILURE;
+	}
+	if (partial)
+		printf("Partial completion\n");
+	printf("%zu message(s) %s\n", eids.size(), g_copy ? "copied" : "moved");
+	return EXIT_SUCCESS;
+}
+
+}


### PR DESCRIPTION
## Summary

Adds `movemsg`, a new gromox-mbop subcommand to move or copy a message between folders via exmdb'''s `movecopy_messages`, mirroring the existing single-purpose style of `delmsg`/`emptyfld`. Originally written as a manual test tool while validating an exmdb `message_moved` notification-subscription path, but it fills a real gap: mbop has no existing way to relocate a specific message between folders from the command line.

Second commit adds the man page section (matching the `delmsg`/`emptyfld` documentation style) and fixes the subcommand'''s own usage string, which advertised comma-separated message IDs (`message_id[,...]`) but the parser actually takes them as separate positional arguments, same as `delmsg`.

## Usage

```
gromox-mbop -u a@b.de movemsg -f src_folder_id -t dst_folder_id msgid...
gromox-mbop -u a@b.de movemsg -f src_folder_id -t dst_folder_id --copy msgid...
```