### PR TITLE
Rename ldap_user_template to ldap_user_templates in man page

### DIFF
--- a/doc/ldap_adaptor.4gx
+++ b/doc/ldap_adaptor.4gx
@@ -144,11 +144,11 @@ and \fIldap_user_search_attrs=cn\fP, etc. in the config file.
 .br
 Default: (empty set)
 .TP
-\fBldap_user_template\fP
+\fBldap_user_templates\fP
 The name(s) of Admin API templates to use. Multi-value directive like
-search_attrs. Pick \fBldap_user_template=common\fP and
-\fBldap_user_template=OpenLDAP\fP for OpenLDAP, or
-\fBldap_user_template=common\fP and \fPldap_user_template=ActiveDirectory\fP
+search_attrs. Pick \fBldap_user_templates=common\fP and
+\fBldap_user_templates=OpenLDAP\fP for OpenLDAP, or
+\fBldap_user_templates=common\fP and \fPldap_user_templates=ActiveDirectory\fP
 for Active Directory.
 .br
 Default: (empty set)


### PR DESCRIPTION
The ldap user template setting is called "ldap_user_templates", not "ldap_user_template".