### PR TITLE
ruleproc: allow back-to-back room bookings

### DIFF
--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -1528,9 +1528,13 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 				par.cur.dirc(), mapi_strerror(err));
 
 		for (const freebusy_event &event : fbdata)
-			if ((event.start_time >= start_ts && event.start_time <= end_ts) ||
-			    (event.end_time   >= start_ts && event.end_time <= end_ts) ||
-			    (event.start_time < start_ts  && event.end_time > end_ts))
+			/*
+			 * Calendar slots are half-open intervals [start, end):
+			 * two ranges conflict iff each starts strictly before the
+			 * other ends. Back-to-back bookings (one ends exactly when
+			 * the next begins) share only the boundary and do not clash.
+			 */
+			if (event.start_time < end_ts && event.end_time > start_ts)
 				if (event.busy_status != olFree) {
 					res_in_use = true;
 					break;


### PR DESCRIPTION
## Problem

A room that disallows conflicting bookings rejects meetings that are merely
*adjacent* to an existing one. For example, with an existing booking
11:00–11:30, a new request for 11:30–12:00 is declined as a conflict even
though the two do not actually overlap. The rejection is symmetric: booking
11:00–11:30 against an existing 11:30–12:00 fails the same way.

There is no configuration workaround — `decline_overlap` derives from the
room's `PR_SCHDINFO_DISALLOW_OVERLAPPING_APPTS` and is all-or-nothing
(disabling it also permits genuine double-bookings).

## Cause

The double-booking check in `mr_do_request` (`lib/ruleproc.cpp`) compared the requested slot against each free/busy event using inclusive `>=` / `<=` boundaries:

```cpp
if ((event.start_time >= start_ts && event.start_time <= end_ts) ||
    (event.end_time   >= start_ts && event.end_time   <= end_ts) ||
    (event.start_time < start_ts  && event.end_time   > end_ts))
```

Calendar slots are half-open intervals [start, end), so an existing event whose end_time equals the new booking's start_ts (they only touch at the boundary) was wrongly counted as an overlap.

Fix

Replace the three inclusive clauses with the canonical half-open overlap test — two intervals conflict iff each starts strictly before the other ends:
```cpp
if (event.start_time < end_ts && event.end_time > start_ts)
```
- Adjacent bookings (existing end == new start, either direction) → no conflict.
- Partial, contained, or identical overlaps → still a conflict.