### PR TITLE
smtp: advertise SMTPUTF8 in delivery-queue's EHLO response

### DIFF
--- a/mda/smtp/cmd.cpp
+++ b/mda/smtp/cmd.cpp
@@ -81,7 +81,8 @@ static int cmdh_xhlo(std::string_view cmd_line, smtp_context &ctx) try
 	string_length += gx_snprintf(&buff[string_length], std::size(buff) - string_length,
         "250-HELP\r\n"
 		"250-SIZE %zu\r\n"
-        "250 8BITMIME\r\n",
+        "250-8BITMIME\r\n"
+        "250 SMTPUTF8\r\n",
         /* send the size of "SIZE" command */
 		g_param.max_mail_length);
 


### PR DESCRIPTION
### Problem

gromox-delivery-queue (mda/smtp/*, the internal SMTP receiver that Postfix's `virtual_transport` relays local/virtual mail to, typically on `127.0.0.1:24`) never advertised `SMTPUTF8` in its EHLO capability list:

```
250-PIPELINING
250-HELP
250-SIZE 67108864
250 8BITMIME
```

Meanwhile Postfix's own public-facing smtpd/submission listeners advertise SMTPUTF8 by default. When an external sender negotiates SMTPUTF8 on the way in (or when Postfix otherwise tags a queued message as requiring it, e.g. via a mailbox forwarding rule re-injecting a message that already carries the flag), Postfix's outbound SMTP client refuses to relay that message onward to any next-hop that doesn't itself offer SMTPUTF8. Since gromox-delivery-queue never advertised it, every such message was **permanently bounced**:

```
dsn=5.6.7, status=bounced (SMTPUTF8 is required, but was not offered by host ::1[::1])
```

This reproduced reliably in production and caused real, user-facing mail loss (silent permanent bounce back to the original sender) for any message tagged SMTPUTF8, including plain internal-forward re-delivery.

Note `mda/lda.cpp` (a separate local-pipe delivery agent) already advertises `SMTPUTF8` correctly - this PR just brings the actual SMTP-listening delivery-queue daemon in line with it.

### Fix

Add `250-SMTPUTF8` to the EHLO response built in `mda/smtp/cmd.cpp`'s `cmdh_xhlo()`.

### Testing

Built and installed on a production host. Verified via a manual EHLO on the delivery-queue port before/after:

```
# before
250-HELP
250-SIZE 67108864
250 8BITMIME

# after
250-HELP
250-SIZE 67108864
250-8BITMIME
250 SMTPUTF8
```

End-to-end: sent a real message via `MAIL FROM:...  SMTPUTF8` to a local mailbox with an active forwarding rule (the exact path that was bouncing in production). Before the fix this bounced with `dsn=5.6.7`; after the fix, Postfix's log shows clean delivery:

```
to=<...>, orig_to=<...>, relay=::1[::1]:24, dsn=2.0.0, status=sent (250 Ok queue-id: 1)
```
