### PR TITLE
ews: implement MarkAsJunk

### DIFF
--- a/exch/ews/ews.cpp
+++ b/exch/ews/ews.cpp
@@ -292,6 +292,7 @@ const std::unordered_map<std::string, EWSPlugin::Handler> EWSPlugin::requestMap 
 	{"GetUserConfiguration", process<Structures::mGetUserConfigurationRequest>},
 	{"GetUserOofSettingsRequest", process<Structures::mGetUserOofSettingsRequest>},
 	{"GetUserPhoto", process<Structures::mGetUserPhotoRequest>},
+	{"MarkAsJunk", process<Structures::mMarkAsJunkRequest>},
 	{"MoveFolder", process<Structures::mMoveFolderRequest>},
 	{"MoveItem", process<Structures::mMoveItemRequest>},
 	{"RemoveDelegate", process<Structures::mRemoveDelegateRequest>},

--- a/exch/ews/exceptions.hpp
+++ b/exch/ews/exceptions.hpp
@@ -600,6 +600,8 @@ E(3468, "failed to move sent message to Sent Items");
 E(3469, "failed to delete draft after send");
 E(3470, "only the organizer can cancel a meeting");
 E(3471, "failed to delete cancelled meeting");
+E(3472, "cannot read from item's source folder");
+E(3473, "cannot write to destination folder");
 
 #undef E
 }

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -2299,6 +2299,59 @@ void process(const mBaseMoveCopyItem &request, XMLElement *response, const EWSCo
 }
 
 /**
+ * @brief      Process MarkAsJunk
+ *
+ * Moves item(s) to or from the Junk Email folder (IsJunk selects the
+ * direction, MoveItem gates whether anything is actually moved).
+ *
+ * The blocked/safe sender list update that real Exchange performs as
+ * part of this operation is not implemented - gromox currently has no
+ * data model for such a list, so this only covers the move semantics.
+ *
+ * @param      request   Request data
+ * @param      response  XMLElement to store response in
+ * @param      ctx       Request context
+ */
+void process(mMarkAsJunkRequest &&request, XMLElement *response, const EWSContext &ctx)
+{
+	response->SetName("m:MarkAsJunkResponse");
+
+	mMarkAsJunkResponse data;
+	data.ResponseMessages.reserve(request.ItemIds.size());
+
+	for (const auto &id : request.ItemIds) try {
+		tItemId itemId = id.itemId();
+		ctx.assertIdType(itemId.type, tItemId::ID_ITEM);
+		sMessageEntryId meid(itemId.Id.data(), itemId.Id.size());
+		sFolderSpec sourceFolder = ctx.resolveFolder(meid);
+		std::string dir = ctx.getDir(sourceFolder);
+		ctx.validate(dir, meid);
+		if (!(ctx.permissions(dir, sourceFolder.folderId) & frightsReadAny))
+			throw EWSError::AccessDenied(E3472);
+
+		auto &msg = data.ResponseMessages.emplace_back();
+		if (request.MoveItem) {
+			sFolderSpec dstFolder = ctx.resolveFolder(tDistinguishedFolderId(
+				request.IsJunk ? Enum::junkemail : Enum::inbox));
+			dstFolder.target = sourceFolder.target;
+			dstFolder.normalize();
+			std::string dstDir = ctx.getDir(dstFolder);
+			if (!(ctx.permissions(dstDir, dstFolder.folderId) & frightsCreate))
+				throw EWSError::AccessDenied(E3473);
+			uint64_t newItemId = ctx.moveCopyItem(dir, meid, dstFolder.folderId, false);
+			sShape idShape{tItemResponseShape()};
+			sItem movedItem = ctx.loadItem(dstDir, dstFolder.folderId, newItemId, idShape);
+			msg.MovedItemId = std::visit([](auto &&i) -> std::optional<tItemId> {return i.ItemId;}, movedItem);
+		}
+		msg.success();
+	} catch(const EWSError& err) {
+		data.ResponseMessages.emplace_back(err);
+	}
+
+	data.serialize(response);
+}
+
+/**
  * @brief      Process SetUserOofSettingsRequest
  *
  * Provides functionality of SetUserOofSettingsRequest

--- a/exch/ews/requests.hpp
+++ b/exch/ews/requests.hpp
@@ -48,6 +48,7 @@ EWSFUNC(mGetUserAvailabilityRequest);
 EWSFUNC(mGetUserConfigurationRequest);
 EWSFUNC(mGetUserOofSettingsRequest);
 EWSFUNC_NC(mGetUserPhotoRequest);
+EWSFUNC(mMarkAsJunkRequest);
 void process(const Structures::mBaseMoveCopyFolder &, tinyxml2::XMLElement *, const gromox::EWS::EWSContext &);
 void process(const Structures::mBaseMoveCopyItem &, tinyxml2::XMLElement *, const gromox::EWS::EWSContext &);
 EWSFUNC(mRemoveDelegateRequest);

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -1893,6 +1893,23 @@ void mConvertIdResponseMessage::serialize(tinyxml2::XMLElement *xml) const
 		altid->SetAttribute("xsi:type", "t:AlternateIdType");
 }
 
+mMarkAsJunkRequest::mMarkAsJunkRequest(const tinyxml2::XMLElement *xml) :
+	XMLINIT(ItemIds),
+	XMLINITA(IsJunk),
+	XMLINITA(MoveItem)
+{}
+
+void mMarkAsJunkResponse::serialize(tinyxml2::XMLElement *xml) const
+{
+	XMLDUMPM(ResponseMessages);
+}
+
+void mMarkAsJunkResponseMessage::serialize(tinyxml2::XMLElement *xml) const
+{
+	mResponseMessageType::serialize(xml);
+	XMLDUMPM(MovedItemId);
+}
+
 mCopyFolderRequest::mCopyFolderRequest(const tinyxml2::XMLElement *xml) :
 	mBaseMoveCopyFolder(xml, true)
 {}

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -3950,6 +3950,39 @@ struct mGetUserOofSettingsResponse {
 };
 
 /**
+ * Messages.xsd:1968
+ */
+struct mMarkAsJunkRequest {
+	explicit mMarkAsJunkRequest(const tinyxml2::XMLElement *);
+
+	std::vector<sBaseItemId> ItemIds;
+	bool IsJunk; //Attribute
+	bool MoveItem; //Attribute
+};
+
+/**
+ * Messages.xsd:1980
+ */
+struct mMarkAsJunkResponseMessage : public mResponseMessageType {
+	static constexpr char NAME[] = "MarkAsJunkResponseMessage";
+
+	using mResponseMessageType::mResponseMessageType;
+
+	std::optional<tItemId> MovedItemId;
+
+	void serialize(tinyxml2::XMLElement *) const;
+};
+
+/**
+ * Messages.xsd:1975
+ */
+struct mMarkAsJunkResponse {
+	std::vector<mMarkAsJunkResponseMessage> ResponseMessages;
+
+	void serialize(tinyxml2::XMLElement *) const;
+};
+
+/**
  * Messages.xsd:873
  */
 struct mMoveFolderRequest : public mBaseMoveCopyFolder {


### PR DESCRIPTION
### Problem

Outlook (confirmed on Outlook for Mac, but this is standard Outlook behavior generally) uses the dedicated `MarkAsJunk` EWS operation - not `MoveItem` - when a message is dragged to or from the Junk Email folder. gromox-ews had no handler for this operation at all, so every such request failed:

```
[ews#384] Done, code 500: unknown request 'MarkAsJunk'
```

Outlook swallows this error silently (no dialog, no visible feedback) - the message just doesn't move, with nothing to tell the user why.

### Fix

Implements `MarkAsJunk` per the documented operation semantics (https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/markasjunk-operation):

- `IsJunk` selects the destination folder: `true` -> Junk Email, `false` -> Inbox.
- `MoveItem` gates whether anything is actually moved; if `false`, no move happens.
- The response carries `MovedItemId` when a move occurred, matching the documented response shape.

Both directions (into and out of Junk) are handled by the same code path - it's symmetric by construction, just swapping the destination distinguished folder based on `IsJunk`.

Implementation reuses the existing `EWSContext::moveCopyItem()` primitive, i.e. the same underlying move mechanism `MoveItem`/`CopyItem` already use - no new move logic, just new request/response (de)serialization types (`mMarkAsJunkRequest`/`mMarkAsJunkResponse`/`mMarkAsJunkResponseMessage`) and a handler that resolves the source folder, permission-checks both source and destination, and calls the existing move primitive.

### Explicitly not implemented

Real Exchange's `MarkAsJunk` also adds/removes the sender from a blocked-sender list as part of this operation. gromox currently has no data model for that at all (`PR_JUNK_ADD_RECIPS_TO_SSL` is defined in `mapitags.hpp` but unused anywhere, and there's no blocked/safe-senders storage or lookup path). Implementing that properly would need new named-property/storage design work, which felt out of scope for unblocking the actual client-visible symptom (the move failing outright). Flagging this clearly rather than silently only doing half the operation - happy to hear if there's an existing convention for this I'm missing, or if it's worth a follow-up.

### Testing

Built clean against current `prime`. Deployed to a production host and tested live with real Outlook for Mac against a real mailbox: moving a message into Junk and back out to Inbox both work correctly now (previously: silent no-op with a 500 in the server log). No regressions observed in other EWS traffic (FindPeople/GetEvents polling continued working normally throughout).
