### PR TITLE
exmdb: fix inverted ST_ENABLED test for extended rules

### DIFF
--- a/exch/exmdb/message.cpp
+++ b/exch/exmdb/message.cpp
@@ -2125,7 +2125,7 @@ static BOOL message_load_folder_ext_rules(const rulexec_in &rp,
 		uint32_t state = pstmt.col_uint64(1);
 		if (state & (ST_PARSE_ERROR | ST_ERROR))
 			continue;
-		if (state & ST_ENABLED)
+		if (!(state & ST_ENABLED))
 			continue;
 		if (state & ST_ONLY_WHEN_OOF && !rp.oof)
 			continue;


### PR DESCRIPTION
b18cb1741 dropped the negation, so message_load_folder_ext_rules now skips every enabled extended rule and keeps only disabled ones -- the inverse of message_load_folder_rules, which the same series fixed correctly.


