### PR TITLE
exmdb: fix new-message ordering in msgtime_index-sorted content tables

### DIFF
--- a/exch/exmdb/db_engine.cpp
+++ b/exch/exmdb/db_engine.cpp
@@ -521,7 +521,8 @@ table_node::table_node(const table_node &o, clone_t) :
 	folder_id(o.folder_id), handle_guid(o.handle_guid),
 	prestriction(o.prestriction), psorts(o.psorts),
 	instance_tag(o.instance_tag), extremum_tag(o.extremum_tag),
-	header_id(o.header_id), b_search(o.b_search), b_hint(o.b_hint)
+	header_id(o.header_id), accel_tag(o.accel_tag), accel_dir(o.accel_dir),
+	b_search(o.b_search), b_hint(o.b_hint)
 {}
 
 table_node::~table_node()
@@ -1751,7 +1752,8 @@ static void dbeng_notify_cttbl_add_row(db_conn &db, uint64_t folder_id,
 		}
 		datagram.id_array[0] = datagram1.id_array[0] =
 			ptable->table_id; // reserved earlier
-		if (NULL == ptable->psorts) {
+		if (NULL == ptable->psorts && ptable->accel_dir == 0) {
+			/* Genuinely unsorted table: append the new row at the bottom. */
 			char sql_string[148];
 			snprintf(sql_string, std::size(sql_string), "SELECT "
 				"count(*) FROM t%u", ptable->table_id);
@@ -1797,14 +1799,35 @@ static void dbeng_notify_cttbl_add_row(db_conn &db, uint64_t folder_id,
 			                          db_notify_type::cttbl_row_added;
 			notifq.emplace_back(datagram, table_to_idarray(*ptable));
 			continue;
-		} else if (0 == ptable->psorts->ccategories) {
-			for (size_t i = 0; i < ptable->psorts->count; ++i) {
-				propvals[i].proptag = PROP_TAG(ptable->psorts->psort[i].type, ptable->psorts->psort[i].propid);
+		} else if (ptable->psorts == nullptr || 0 == ptable->psorts->ccategories) {
+			/*
+			 * Uncategorized sort, or an accel/msgtime_index table (psorts is
+			 * null; the single sort key lives in accel_tag/accel_dir). Compute
+			 * the insertion point so new rows are positioned rather than
+			 * appended at the bottom (which is what the accel path did before
+			 * and caused new mail to sort to the end in online-mode clients).
+			 */
+			proptype_t sort_type[MAXIMUM_SORT_COUNT];
+			bool sort_asc[MAXIMUM_SORT_COUNT];
+			size_t sort_count;
+			if (ptable->psorts != nullptr) {
+				sort_count = ptable->psorts->count;
+				for (size_t i = 0; i < sort_count; ++i) {
+					sort_type[i] = ptable->psorts->psort[i].type;
+					sort_asc[i] = ptable->psorts->psort[i].table_sort == TABLE_SORT_ASCEND;
+					propvals[i].proptag = PROP_TAG(ptable->psorts->psort[i].type, ptable->psorts->psort[i].propid);
+				}
+			} else {
+				sort_count = 1;
+				sort_type[0] = PROP_TYPE(ptable->accel_tag);
+				sort_asc[0] = ptable->accel_dir > 0;
+				propvals[0].proptag = ptable->accel_tag;
+			}
+			for (size_t i = 0; i < sort_count; ++i)
 				if (!cu_get_property(MAPI_MESSAGE, message_id,
 				    ptable->cpid, db, propvals[i].proptag,
 				    &propvals[i].pvalue))
 					return;
-			}
 			char sql_string[148];
 			snprintf(sql_string, std::size(sql_string), "SELECT row_id, inst_id,"
 				" idx FROM t%u ORDER BY idx ASC", ptable->table_id);
@@ -1820,19 +1843,33 @@ static void dbeng_notify_cttbl_add_row(db_conn &db, uint64_t folder_id,
 				row_id1 = sqlite3_column_int64(pstmt, 0);
 				inst_id1 = sqlite3_column_int64(pstmt, 1);
 				idx = sqlite3_column_int64(pstmt, 2);
-				for (size_t i = 0; i < ptable->psorts->count; ++i) {
+				bool b_equal = true;
+				for (size_t i = 0; i < sort_count; ++i) {
 					void *pvalue = nullptr;
 					if (!cu_get_property(MAPI_MESSAGE, inst_id1,
 					    ptable->cpid, db,
 					    propvals[i].proptag, &pvalue))
 						return;
-					auto result = db_engine_compare_propval(ptable->psorts->psort[i].type, propvals[i].pvalue, pvalue);
-					auto asc = ptable->psorts->psort[i].table_sort == TABLE_SORT_ASCEND;
-					if ((asc && result < 0) || (!asc && result > 0))
+					auto result = db_engine_compare_propval(sort_type[i], propvals[i].pvalue, pvalue);
+					if ((sort_asc[i] && result < 0) || (!sort_asc[i] && result > 0))
 						b_break = TRUE;
-					if (result != 0)
+					if (result != 0) {
+						b_equal = false;
 						break;
+					}
 				}
+				/*
+				 * All sort keys equal: break ties by message_id in the primary
+				 * sort direction, mirroring the msgtime_index (folder_id, <ts>,
+				 * message_id) load order and the stbl message_id tiebreak in
+				 * gct_makequery. Without this a newly delivered same-key message
+				 * is appended below its peers here but a reload sorts it among
+				 * them, so online-mode clients show it misordered/duplicated.
+				 */
+				if (b_equal && !b_break &&
+				    ((sort_asc[0] && message_id < inst_id1) ||
+				    (!sort_asc[0] && message_id > inst_id1)))
+					b_break = TRUE;
 				if (b_break)
 					break;
 			}

--- a/exch/exmdb/db_engine.hpp
+++ b/exch/exmdb/db_engine.hpp
@@ -66,6 +66,14 @@ struct table_node {
 	RESTRICTION *prestriction = nullptr;
 	SORTORDER_SET *psorts = nullptr;
 	uint32_t instance_tag = 0, extremum_tag = 0, header_id = 0;
+	/*
+	 * accel/msgtime_index-sorted content tables leave psorts null (the fast
+	 * load path in table.cpp), but remember the single sort key here so live
+	 * row-insert notifications can position new rows instead of appending
+	 * them at the bottom. accel_dir==0 means "not accel-sorted".
+	 */
+	uint32_t accel_tag = 0;
+	int accel_dir = 0;
 	BOOL b_search = false;
 	BOOL b_hint = false; /* is table touched in batch-mode */
 };

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -378,6 +378,17 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 				qstr += fmt::format(", v{:x} {}", tmp_proptag, ord);
 			}
 		}
+		/*
+		 * For an uncategorized table, break ties on message_id (in the
+		 * primary sort direction) so a reload reproduces the order that the
+		 * live-insert notification path builds; otherwise same-key rows can
+		 * appear reordered/duplicated in online-mode clients.
+		 */
+		if (b_orderby && psorts->ccategories == 0) {
+			auto ord = psorts->psort[0].table_sort == TABLE_SORT_ASCEND ?
+			           " ASC" : " DESC";
+			qstr += fmt::format(", message_id {}", ord);
+		}
 		auto pstmt = gx_sql_prep(psqlite, qstr);
 		if (pstmt == nullptr)
 			return FALSE;
@@ -622,15 +633,24 @@ static std::string gct_makequery(uint64_t fid_val, unsigned int flags,
 	 */
 	static constexpr char order_kw[2][5] = {"DESC", "ASC"};
 	auto adir = order_kw[accel_pair.dir > 0];
+	/*
+	 * The message_id tiebreak matches the (folder_id, <ts>, message_id) index
+	 * and the live-insert notification path (dbeng_notify_cttbl_add_row), so a
+	 * fresh load reproduces exactly what incremental notifications built. Same
+	 * direction as the primary key keeps the ORDER BY index-satisfiable.
+	 */
 	if (accel_pair.tag == PR_LAST_MODIFICATION_TIME)
 		return fmt::format("SELECT message_id FROM msgtime_index "
-		       "WHERE folder_id={} ORDER BY mtime {}", LLU{fid_val}, adir);
+		       "WHERE folder_id={} ORDER BY mtime {}, message_id {}",
+		       LLU{fid_val}, adir, adir);
 	else if (accel_pair.tag == PR_MESSAGE_DELIVERY_TIME)
 		return fmt::format("SELECT message_id FROM msgtime_index "
-		       "WHERE folder_id={} ORDER BY rcvtime {}", LLU{fid_val}, adir);
+		       "WHERE folder_id={} ORDER BY rcvtime {}, message_id {}",
+		       LLU{fid_val}, adir, adir);
 	else if (accel_pair.tag == PR_CLIENT_SUBMIT_TIME)
 		return fmt::format("SELECT message_id FROM msgtime_index "
-		       "WHERE folder_id={} ORDER BY sndtime {}", LLU{fid_val}, adir);
+		       "WHERE folder_id={} ORDER BY sndtime {}, message_id {}",
+		       LLU{fid_val}, adir, adir);
 
 	auto b_del = flags & TABLE_FLAG_SOFTDELETES;
 	if (flags & TABLE_FLAG_CONVERSATIONMEMBERS)
@@ -756,8 +776,16 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 	if ((table_flags & (TABLE_FLAG_CONVERSATIONMEMBERS | TABLE_FLAG_ASSOCIATED | TABLE_FLAG_SOFTDELETES)) == 0 &&
 	    !b_search)
 		accel_pair = accel_sorting(psorts);
-	if (accel_pair.dir != 0)
+	if (accel_pair.dir != 0) {
+		/*
+		 * The accel/msgtime_index path loads without a stored sort order,
+		 * but the live row-insert notification path needs to know the sort
+		 * key to position new rows (rather than append at the bottom).
+		 */
+		ptnode->accel_tag = accel_pair.tag;
+		ptnode->accel_dir = accel_pair.dir;
 		psorts = nullptr;
+	}
 	if (NULL != psorts) {
 		/*
 		 * The propvals of the sort criterion proptags are copied from


### PR DESCRIPTION
### Problem

In Outlook **online (non-cached) mode**, a mail arriving into an *open* Inbox sorted by Received date shows up at the bottom of the list and is briefly displayed twice; switching folders and back fixes it. Reported at https://community.grommunio.com/d/2381 (Outlook 2016/2021/2024, present since ~3.1, still in 3.4.80). Cached mode is unaffected because the client sorts locally.

### Root cause

A content table sorted by delivery/modification/submit time is loaded via the `msgtime_index` fast path added in `c104ecab5` (DESK-3893), which sets `table_node::psorts = nullptr`. `dbeng_notify_cttbl_add_row` treats a null `psorts` as "unsorted" and appends the new row at the bottom of the table. So a message delivered into an open time-sorted folder is placed at the end until the table is reloaded (which re-sorts correctly via `msgtime_index`). The mis-anchored `cttbl_row_added` notification vs. the client's own range queries is what produces the transient duplicate.

The uncategorised `stbl` comparison branch positions rows correctly but has no tiebreaker, so equal-key rows (large groups under non-time sorts) can also diverge from the reload order.

### Fix

- `table_node` remembers the accel sort key (`accel_tag`/`accel_dir`) even though `psorts` stays null for the fast load path.
- `dbeng_notify_cttbl_add_row`: the append-at-bottom branch now applies only to genuinely unsorted tables (`psorts == NULL && accel_dir == 0`); accel-sorted tables go through the comparison branch (generalised to the single accel column) and are positioned, not appended.
- Ties break on `message_id` in the primary sort direction, matching the `(folder_id, <ts>, message_id)` index. The accel load queries and the flat `stbl` readback get the same `message_id` tiebreak so a reload reproduces the order incremental notifications build.
