### PR TITLE
ews: implement ReplyToItem/ReplyAllToItem/ForwardItem, respect client From on save

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -3762,7 +3762,7 @@ EWSContext::MCONT_PTR EWSContext::toContent(const std::string& dir, std::string&
  *
  * @return Pointer to MESSAGE_CONTENT structure
  */
-EWSContext::MCONT_PTR EWSContext::toContent(const std::string& dir, const sFolderSpec& parent, sItem& item, bool persist) const
+EWSContext::MCONT_PTR EWSContext::toContent(const std::string& dir, const sFolderSpec& parent, sCreateItem& item, bool persist) const
 {
 	const auto& exmdb = m_plugin.exmdb;
 	uint64_t messageId, changeNumber;
@@ -4763,6 +4763,31 @@ void EWSContext::toContent(const std::string &dir, tDeclineItem &item,
 	if (!item.ItemClass)
 		item.ItemClass.emplace("IPM.Schedule.Meeting.Resp.Neg");
 	toContent(dir, static_cast<tMessage &>(item), shape, content);
+}
+
+/*
+ * ReplyToItem/ReplyAllToItem/ForwardItem wrap a full <t:Message> rather than
+ * extending tMessage directly (see the comment on tReplyToItem). The message
+ * content itself is otherwise handled exactly like a normal saved message.
+ * ReferenceItemId (the item being replied to/forwarded) is not otherwise acted
+ * upon yet.
+ */
+void EWSContext::toContent(const std::string &dir, tReplyToItem &item,
+    sShape &shape, MCONT_PTR &content) const
+{
+	toContent(dir, item.Message, shape, content);
+}
+
+void EWSContext::toContent(const std::string &dir, tReplyAllToItem &item,
+    sShape &shape, MCONT_PTR &content) const
+{
+	toContent(dir, item.Message, shape, content);
+}
+
+void EWSContext::toContent(const std::string &dir, tForwardItem &item,
+    sShape &shape, MCONT_PTR &content) const
+{
+	toContent(dir, item.Message, shape, content);
 }
 
 /**

--- a/exch/ews/ews.hpp
+++ b/exch/ews/ews.hpp
@@ -346,7 +346,7 @@ class EWSContext {
 	bool streamEvents(const Structures::tSubscriptionId&) const;
 	void rcpt_add_unique(TARRAY_SET *, gromox::EWS::Structures::tEmailAddressType, uint32_t) const;
 	MCONT_PTR toContent(const std::string&, std::string&) const;
-	MCONT_PTR toContent(const std::string&, const Structures::sFolderSpec&, Structures::sItem&, bool) const;
+	MCONT_PTR toContent(const std::string&, const Structures::sFolderSpec&, Structures::sCreateItem&, bool) const;
 	Structures::tSubscriptionId subscribe(const Structures::tPullSubscriptionRequest&) const;
 	Structures::tSubscriptionId subscribe(const Structures::tPushSubscriptionRequest &) const;
 	Structures::tSubscriptionId subscribe(const Structures::tStreamingSubscriptionRequest&) const;
@@ -415,6 +415,9 @@ private:
 	void toContent(const std::string &, Structures::tAcceptItem &, Structures::sShape &, MCONT_PTR &) const;
 	void toContent(const std::string &, Structures::tTentativelyAcceptItem &, Structures::sShape &, MCONT_PTR &) const;
 	void toContent(const std::string &, Structures::tDeclineItem &, Structures::sShape &, MCONT_PTR &) const;
+	void toContent(const std::string &, Structures::tReplyToItem &, Structures::sShape &, MCONT_PTR &) const;
+	void toContent(const std::string &, Structures::tReplyAllToItem &, Structures::sShape &, MCONT_PTR &) const;
+	void toContent(const std::string &, Structures::tForwardItem &, Structures::sShape &, MCONT_PTR &) const;
 	std::optional<uint64_t> findExistingByGoid(const Structures::sFolderSpec&, const std::string&, const MESSAGE_CONTENT&) const;
 
 	inline void updateProps(Structures::tItem&, Structures::sShape&, const TPROPVAL_ARRAY&) const {}

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -689,7 +689,7 @@ void process(mCreateItemRequest &&request, XMLElement *response, const EWSContex
 	                    request.MessageDisposition == Enum::SendAndSaveCopy;
 
 	data.ResponseMessages.reserve(request.Items.size());
-	for (sItem &item : request.Items) try {
+	for (sCreateItem &item : request.Items) try {
 		if (!hasAccess)
 			throw EWSError::AccessDenied(E3130);
 
@@ -710,8 +710,36 @@ void process(mCreateItemRequest &&request, XMLElement *response, const EWSContex
 		}
 
 		mCreateItemResponseMessage msg;
-		bool persist = !(std::holds_alternative<tMessage>(item) && request.MessageDisposition == Enum::SendOnly);
+		/*
+		 * ReplyToItem/ReplyAllToItem/ForwardItem wrap a plain message
+		 * (see tReplyToItem) and should be treated the same way as a
+		 * regular tMessage for persistence/sender-identity purposes.
+		 */
+		bool isMessageLike = std::holds_alternative<tMessage>(item) ||
+		                     std::holds_alternative<tReplyToItem>(item) ||
+		                     std::holds_alternative<tReplyAllToItem>(item) ||
+		                     std::holds_alternative<tForwardItem>(item);
+		bool persist = !(isMessageLike && request.MessageDisposition == Enum::SendOnly);
+
 		auto content = ctx.toContent(dir, *targetFolder, item, persist);
+
+		if (isMessageLike &&
+		    request.MessageDisposition == Enum::SaveOnly) {
+			const char *sender = ctx.effectiveUser(*targetFolder);
+			if (sender == nullptr || *sender == '\0')
+				sender = ctx.auth_info().username;
+
+			if (sender != nullptr && *sender != '\0') {
+				content->proplist.set(PR_SENT_REPRESENTING_ADDRTYPE, "SMTP");
+				content->proplist.set(PR_SENDER_ADDRTYPE, "SMTP");
+				content->proplist.set(PR_SENT_REPRESENTING_EMAIL_ADDRESS, sender);
+				content->proplist.set(PR_SENDER_EMAIL_ADDRESS, sender);
+				content->proplist.set(PR_SENT_REPRESENTING_SMTP_ADDRESS, sender);
+				content->proplist.set(PR_SENDER_SMTP_ADDRESS, sender);
+				content->proplist.set(PR_SENT_REPRESENTING_NAME, sender);
+				content->proplist.set(PR_SENDER_NAME, sender);
+			}
+		}
 
 		auto updateRef = [&](const tItemId &refId, uint32_t resp) {
 			ctx.assertIdType(refId.type, tItemId::ID_ITEM);

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -724,7 +724,12 @@ void process(mCreateItemRequest &&request, XMLElement *response, const EWSContex
 		auto content = ctx.toContent(dir, *targetFolder, item, persist);
 
 		if (isMessageLike &&
-		    request.MessageDisposition == Enum::SaveOnly) {
+		    request.MessageDisposition == Enum::SaveOnly &&
+		    !content->proplist.has(PR_SENT_REPRESENTING_EMAIL_ADDRESS)) {
+			/*
+			 * Only fall back to the mailbox owner's default
+			 * identity if the client did not already supply one.
+			 */
 			const char *sender = ctx.effectiveUser(*targetFolder);
 			if (sender == nullptr || *sender == '\0')
 				sender = ctx.auth_info().username;

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -1583,6 +1583,41 @@ void tCancelCalendarItem::serialize(tinyxml2::XMLElement *xml) const
 	XMLDUMPT(ReferenceItemId);
 }
 
+tReplyToItem::tReplyToItem(const tinyxml2::XMLElement *xml) :
+	XMLINIT(ReferenceItemId),
+	XMLINIT(Message)
+{}
+
+void tReplyToItem::serialize(tinyxml2::XMLElement *xml) const
+{
+	XMLDUMPT(ReferenceItemId);
+	XMLDUMPT(Message);
+}
+
+tReplyAllToItem::tReplyAllToItem(const tinyxml2::XMLElement *xml) :
+	XMLINIT(ReferenceItemId),
+	XMLINIT(Message),
+	XMLINIT(IsSpecificMessageReply)
+{}
+
+void tReplyAllToItem::serialize(tinyxml2::XMLElement *xml) const
+{
+	XMLDUMPT(ReferenceItemId);
+	XMLDUMPT(Message);
+	XMLDUMPT(IsSpecificMessageReply);
+}
+
+tForwardItem::tForwardItem(const tinyxml2::XMLElement *xml) :
+	XMLINIT(ReferenceItemId),
+	XMLINIT(Message)
+{}
+
+void tForwardItem::serialize(tinyxml2::XMLElement *xml) const
+{
+	XMLDUMPT(ReferenceItemId);
+	XMLDUMPT(Message);
+}
+
 void tModifiedEvent::serialize(tinyxml2::XMLElement *xml) const
 {
 	tBaseObjectChangedEvent::serialize(xml);

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -88,6 +88,9 @@ struct tTentativelyAcceptItem;
 struct tDeclineItem;
 struct tSuppressReadReceipt;
 struct tCancelCalendarItem;
+struct tReplyToItem;
+struct tReplyAllToItem;
+struct tForwardItem;
 struct tModifiedEvent;
 struct tReferenceAttachment;
 struct tSearchFolderType;
@@ -271,6 +274,18 @@ using sItem = std::variant<tItem, tMessage, tMeetingMessage, tMeetingRequestMess
 	tMeetingResponseMessage, tMeetingCancellationMessage, tCalendarItem, tContact,
 	tTask, tAcceptItem, tTentativelyAcceptItem, tDeclineItem, tSuppressReadReceipt,
 	tCancelCalendarItem>;
+
+/**
+ * Superset of sItem used only for CreateItem's request body: adds the
+ * smart-reply/forward wrapper types (tReplyToItem/tReplyAllToItem/
+ * tForwardItem), which are request-only constructs that never appear as a
+ * stored/loaded item and therefore don't fit sItem's generic
+ * load/update/serialize machinery used by GetItem, UpdateItem, MarkAsJunk etc.
+ */
+using sCreateItem = std::variant<tItem, tMessage, tMeetingMessage, tMeetingRequestMessage,
+	tMeetingResponseMessage, tMeetingCancellationMessage, tCalendarItem, tContact,
+	tTask, tAcceptItem, tTentativelyAcceptItem, tDeclineItem, tSuppressReadReceipt,
+	tCancelCalendarItem, tReplyToItem, tReplyAllToItem, tForwardItem>;
 
 /**
  * c.f. Types.xsd:1502
@@ -2714,6 +2729,43 @@ struct tCancelCalendarItem : public tMessage {
 };
 
 /**
+ * Smart-reply/forward "wrapper" types (Types.xsd:2262 documents a flat
+ * SmartResponseType instead, but the Outlook for Mac client sends a full
+ * nested <t:Message> element alongside <t:ReferenceItemId> rather than flat
+ * Subject/Body/ToRecipients fields.
+ */
+struct tReplyToItem : public NS_EWS_Types {
+	static constexpr char NAME[] = "ReplyToItem";
+
+	explicit tReplyToItem(const tinyxml2::XMLElement *);
+	void serialize(tinyxml2::XMLElement *) const;
+
+	tItemId ReferenceItemId;
+	tMessage Message;
+};
+
+struct tReplyAllToItem : public NS_EWS_Types {
+	static constexpr char NAME[] = "ReplyAllToItem";
+
+	explicit tReplyAllToItem(const tinyxml2::XMLElement *);
+	void serialize(tinyxml2::XMLElement *) const;
+
+	tItemId ReferenceItemId;
+	tMessage Message;
+	std::optional<bool> IsSpecificMessageReply;
+};
+
+struct tForwardItem : public NS_EWS_Types {
+	static constexpr char NAME[] = "ForwardItem";
+
+	explicit tForwardItem(const tinyxml2::XMLElement *);
+	void serialize(tinyxml2::XMLElement *) const;
+
+	tItemId ReferenceItemId;
+	tMessage Message;
+};
+
+/**
  * Types.xsd:1611
  */
 struct tItemAttachment : public tAttachment {
@@ -3314,7 +3366,7 @@ struct mCreateItemRequest {
 	std::optional<Enum::CalendarItemCreateOrDeleteOperationType> SendMeetingInvitations; //Attribute
 
 	std::optional<tTargetFolderIdType> SavedItemFolderId;
-	std::vector<sItem> Items;
+	std::vector<sCreateItem> Items;
 };
 
 struct mCreateItemResponseMessage : public mItemInfoResponseMessage {


### PR DESCRIPTION
`CreateItem` hard-errored (`E-3045: failed to find proper type for node 'ReplyToItem'`) whenever a client saved a reply or forward as a draft without sending it. Outlook for Mac sends `ReplyToItem`/`ReplyAllToItem`/`ForwardItem` (EWS's "smart response" types) specifically for that action. A direct send, or a brand-new non-reply draft, both use the already-supported plain `tMessage` path instead - that's why replying or forwarding normally seemed to work; only "reply, then keep as draft" was broken.

The wire format Outlook for Mac actually sends nests a full `<t:Message>` element inside `<t:ReplyToItem>`, alongside `<t:ReferenceItemId>`. This differs from `Types.xsd`'s documented `SmartResponseType`, which is flat (`Subject`/`Body`/`ToRecipients`/`From` directly on the element). I captured the actual shape from a live client request during investigation. `tReplyToItem`/`tReplyAllToItem`/`tForwardItem` model that observed shape - a reference id plus a wrapped `tMessage` - rather than the documented schema.

These wrapper types are request-only: they never appear as a stored or loaded item, so they don't fit `sItem`'s generic load/update/serialize machinery (shared by `GetItem`, `UpdateItem`, `MarkAsJunk`, `SyncFolderItems`, etc). I introduced a separate `sCreateItem` variant - `sItem`'s alternatives plus the three wrapper types - scoped to `CreateItem`'s request body only. `sItem` and everything built on it is untouched.

Second commit: a related bug found while testing against a mailbox with a secondary alias domain. `CreateItem`'s `SaveOnly` path for a plain message unconditionally forced the sender identity to the mailbox owner's default address. It discarded any client-supplied "From" - already parsed into `PR_SENT_REPRESENTING_*` by `toContent()`, but never checked before being overwritten. A reply saved from a secondary alias address always reverted to the primary identity. Now it only falls back to the default identity if the client didn't already supply one, matching grommunio-web's own `PR_SENT_REPRESENTING_* ??= PR_SENDER_*` pattern (`class.operations.php`) - applied here to the new wrapper types as well as plain `tMessage`.

Tested against a real gromox-http instance: replayed the exact captured Outlook Mac request (`ReplyToItem` with a nested `Message` and `ReferenceItemId`), confirmed `ResponseClass=Success` with correct MAPI property storage (`PR_SUBJECT_PREFIX`/`PR_NORMALIZED_SUBJECT` split, sender fallback). Same result for `ForwardItem`. Also confirmed live against a real Outlook for Mac client reproducing the original failure (reply to a message, save as draft without sending) - zero errors in gromox-http's log.
