### PR TITLE
poll_ctx: fix NULL pointer dereference in epoll_wait() fallback path

### DIFF
--- a/lib/process.cpp
+++ b/lib/process.cpp
@@ -484,7 +484,10 @@ int poll_ctx::wait(const struct timespec *timeout, int max_ev)
 #ifdef HAVE_EPOLL_PWAIT2
 	return epoll_pwait2(m_epfd, m_events.data(), max_ev, timeout, nullptr);
 #else
-	return epoll_wait(m_epfd, m_events.data(), max_ev, timeout->tv_nsec / 1000000 + timeout->tv_sec);
+	int ms = -1; /* -1 = epoll_wait's "block indefinitely" */
+	if (timeout != nullptr)
+		ms = timeout->tv_sec * 1000 + timeout->tv_nsec / 1000000;
+	return epoll_wait(m_epfd, m_events.data(), max_ev, ms);
 #endif
 #elif defined(HAVE_SYS_EVENT_H)
 	return kevent(m_epfd, nullptr, 0, m_events.data(), max_ev, timeout);


### PR DESCRIPTION
`poll_ctx::wait()` accepts a `nullptr` timeout meaning "block indefinitely"; the `HAVE_EPOLL_PWAIT2` branch handles this correctly by forwarding nullptr to the syscall. The fallback branch (taken when `HAVE_EPOLL_PWAIT2` is undefined, e.g. on musl libc) instead unconditionally dereferences `timeout->tv_sec`/`tv_nsec`, causing an immediate SIGSEGV whenever a null timeout is passed.

This crashes every gromox daemon deterministically on startup on musl systems (reproduced on Alpine Linux, musl 1.2.x), since callers like `contexts_pool.cpp`'s `ctxp_thrwork` routinely call `wait()` with a null "wait forever" timeout.

Fix: treat a null `timeout` as `-1` (epoll_wait's own "block indefinitely" convention) instead of dereferencing it.

Fixes #291 