### PR TITLE
lib/contexts_pool: guard contexts_pool_signal() against a null context

### DIFF
--- a/lib/contexts_pool.cpp
+++ b/lib/contexts_pool.cpp
@@ -327,6 +327,8 @@ void contexts_pool_insert(schedule_context *pcontext, sctx_status tpraw)
 
 void contexts_pool_signal(SCHEDULE_CONTEXT *pcontext)
 {
+	if (pcontext == nullptr)
+		return;
 	std::unique_lock idle_hold(g_context_locks[static_cast<int>(sctx_status::idling)]);
 	if (pcontext->type != sctx_status::idling)
 		return;


### PR DESCRIPTION
`contexts_pool_insert()` and co`ntexts_pool_wakeup_context()` both check for a null `pcontext `before dereferencing. `contexts_pool_signal()` lacked the same guard. Add it for consistency and defense-in-depth against callers passing a stale/null pointer.
