### PR TITLE
exch/http: close TOCTOU window in VCONN_REF::put()

### DIFF
--- a/exch/http/http_parser.cpp
+++ b/exch/http/http_parser.cpp
@@ -416,12 +416,12 @@ void VCONN_REF::put()
 {
 	if (pvconnection == nullptr)
 		return;
+	bool empty = pvconnection->pcontext_in == nullptr &&
+		pvconnection->pcontext_out == nullptr;
 	m_hold.unlock();
 	std::unique_lock vc_hold(g_parser->g_vconnection_lock);
 	pvconnection->reference --;
-	if (pvconnection->reference == 0 &&
-	    pvconnection->pcontext_in == nullptr &&
-	    pvconnection->pcontext_out == nullptr) {
+	if (pvconnection->reference == 0 && empty) {
 		auto nd = g_parser->g_vconnection_hash.extract(m_iter);
 		vc_hold.unlock();
 		/* end locked region before running ~nd (~VCONN_REF, pdu_processor_destroy) */


### PR DESCRIPTION
While investigating an unrelated crash, we noticed `VCONN_REF::put()` releases the per-connection lock (`m_hold`) before reading `pcontext_in`/`pcontext_out `to decide whether the `VIRTUAL_CONNECTION `is now empty and safe to erase. This read happens only under the global `g_vconnection_lock`, not the per-connection lock that guards those fields elsewhere (e.g. `try_create_vconnection()`).

This looks like it could allow a connection to be erased concurrently with another thread populating it. This patch reads the emptiness check while still holding `m_hold`. We have not reproduced a concrete crash from this specific race.

**Flagging for maintainer review given your familiarity with the locking invariants here.**
