### PR TITLE
mra/imap: remove context from g_sleeping_list on teardown

### DIFF
--- a/mra/imap/parser.cpp
+++ b/mra/imap/parser.cpp
@@ -962,6 +962,10 @@ static tproc_status ps_end_processing(imap_context *pcontext,
 		pcontext->connection.write(imap_reply_str, string_length);
 	}
 	pcontext->connection.reset(SLEEP_BEFORE_CLOSE);
+	{
+		std::unique_lock ll_hold(g_list_lock);
+		std::erase(g_sleeping_list, pcontext);
+	}
 	if (iproto_stat::select == pcontext->proto_stat) {
 		imap_parser_remove_select(pcontext);
 		pcontext->proto_stat = iproto_stat::auth;


### PR DESCRIPTION
`g_sleeping_list` entries are only ever removed by `imps_thrwork`'s own scan. If a context reaches `ps_end_processing() `(and is recycled back to the free pool) via a different path while still queued in `g_sleeping_list`, `imps_thrwork `could later pop and act on a stale/reused context. This patch scrubs any pending entry at teardown. 

Found via code review, not a confirmed live reproduction.

**Sharing for your assessment.**
