### PR TITLE
nsp: fix GetMatches scanning the unfiltered user list

### DIFF
--- a/exch/nsp/nsp_interface.cpp
+++ b/exch/nsp/nsp_interface.cpp
@@ -1205,8 +1205,18 @@ ec_error_t nsp_interface_get_matches(NSPI_HANDLE handle, uint32_t reserved1,
 		/* Alternative attempt by OL to do resolvenames */
 		uint32_t start_pos, total;
 		nsp_interface_position_in_list(pstat, base.get(), &start_pos, &total);
-		for (auto it = base->ubegin() + start_pos; it != base->uend() &&
-		     static_cast<size_t>(it - base->ubegin()) < total; ++it) {
+		/*
+		 * position_in_list works in GAL-filtered index space (start_pos and
+		 * total both derive from filtered_user_count()), so iterate the
+		 * filtered user set. Previously this walked the *unfiltered* user
+		 * list (ubegin()/uend()) while bounding by the filtered count, which
+		 * truncated the scan once any user was hidden from the GAL: every
+		 * user positioned past filtered_user_count() in the full list was
+		 * never examined and thus never matched by GetMatches (e.g. Outlook
+		 * address-book "search all columns").
+		 */
+		for (auto it = base->ufbegin() + start_pos; it != base->ufend() &&
+		     static_cast<size_t>(it - base->ufbegin()) < total; ++it) {
 			if (outmids.size() >= requested)
 				break;
 			ab_tree::ab_node node(base, *it);


### PR DESCRIPTION
### Problem

In Outlook's address-book search in "All columns" mode (which issues an NSPI `GetMatches` against the GAL), some ordinary users are not returned, even though the same users are found via "Name only" mode (`SeekEntries`+`QueryRows`) and in grommunio-web. Whether a given user is missed does not depend on their attributes but on their position in the directory — which is why it looks like "most searches work, only some fail."

### Root cause

In `nsp_interface_get_matches`, the `container_id == 0` (GAL) branch obtains `start_pos` and `total` from `nsp_interface_position_in_list`, which works entirely in GAL-filtered index space (both values derive from `filtered_user_count()`). The loop then iterates the *unfiltered* user list via `ubegin()`/`uend()` while bounding on `(it - ubegin()) < total`. As soon as any user is hidden from the GAL, `filtered_user_count()` is smaller than the full user count, so the loop stops after `filtered_user_count()` entries of the full list and every user positioned past that index is never examined — and therefore never matched. The name-only browse path and grommunio-web walk the filtered set, so they are unaffected.

### Fix

Iterate the filtered user set (`ufbegin()`/`ufend()`) so the iterator's index space matches the `start_pos`/`total` that `nsp_interface_position_in_list` produced. One-loop change; the per-node `AB_HIDE_RESOLVE`/`AB_HIDE_FROM_GAL` and restriction checks are unchanged.

