### PR TITLE
ews: signal ConnectionStatus=Closed when GetStreamingEvents faults a subscription

### DIFF
--- a/exch/ews/ews.cpp
+++ b/exch/ews/ews.cpp
@@ -734,12 +734,22 @@ int EWSContext::notify()
 	}
 	for (const tSubscriptionId &subscription : msg.ErrorSubscriptionIds)
 		std::erase(nctx.nct_subs, subscription);
-	msg.success();
+	if (msg.ErrorSubscriptionIds.empty())
+		msg.success();
+	else
+		msg.error("ErrorInvalidSubscription", "Subscription is invalid.");
 	// If there are no more subscriptions to monitor or the stream expired, close it
 	// If there were more events than we could deliver in one message, proceed with the next chunk right away
 	// Otherwise just go back to sleep
 	nctx.state = nctx.nct_subs.empty() || tp_now() > nctx.expire ?
 	             NS::S_CLOSING : moreAny ? NS::S_SLEEP : NS::S_WRITE;
+	/*
+	 * Report the connection as closing on the same chunk that reveals a
+	 * faulted subscription, instead of only in a later, disconnected
+	 * "goodbye" chunk. A client reading only this chunk still gets an
+	 * immediate, correct signal to resubscribe.
+	 */
+	msg.ConnectionStatus = nctx.state == NS::S_CLOSING ? Enum::Closed : Enum::OK;
 	if (nctx.state == NS::S_SLEEP)
 		m_plugin.wakeContext(m_ctx_id, m_plugin.event_stream_interval);
 	return flush();

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -1706,11 +1706,18 @@ void process(mGetStreamingEventsRequest &&request, XMLElement *response, EWSCont
 	for (const tSubscriptionId &subscription : request.SubscriptionIds)
 		if (!ctx.streamEvents(subscription))
 			msg.ErrorSubscriptionIds.emplace_back(subscription);
-	if (msg.ErrorSubscriptionIds.empty())
+	if (msg.ErrorSubscriptionIds.empty()) {
 		msg.success();
-	else
+		msg.ConnectionStatus = Enum::OK;
+	} else {
+		/*
+		 * A faulted subscription (e.g. event backlog overflow, see
+		 * EWSPlugin::event()) never becomes valid again on its own.
+		 * The client must Subscribe anew and resync.
+		 */
 		msg.error("ErrorInvalidSubscription", "Subscription is invalid.");
-	msg.ConnectionStatus = Enum::OK;
+		msg.ConnectionStatus = Enum::Closed;
+	}
 
 	data.serialize(response);
 }


### PR DESCRIPTION
A subscription's event backlog can exceed `ews_max_pending_events`. When that happens the server faults it (`EWSPlugin::event()` sets `mgr->overflow`) so that the client re-subscribes and resyncs. `GetStreamingEvents` already reports `ErrorInvalidSubscription` for a faulted subscription, but it unconditionally set `ConnectionStatus=OK` on every response, error or not.

A client that reacts to connection state rather than polling the error code indefinitely gets no signal that this particular streaming connection is done for good. I hit this in production: a real Outlook for Mac client kept calling `GetStreamingEvents` against a faulted subscription every ~50 seconds for over two hours, always getting `ErrorInvalidSubscription` with `ConnectionStatus=OK`, and never re-subscribed on its own. New mail stopped surfacing in the client for the whole window, even though the server was answering every poll with `200 OK`.

This reports `ConnectionStatus=Closed` when the response carries an error, matching the field's documented meaning (the connection is closed, reconnect if you want more events) instead of leaving it at `OK` alongside a fatal error.

Tested by building against the reproduction above (rolled the fix out to the same mailbox that got stuck) - can't easily automate "wait 2+ hours for the real client to give up," but the change itself is a 2-line, low-risk behavioral fix scoped to the already-error branch.
