### PR TITLE
ews: personal Contacts folder integration for GetUserPhoto and FindPeople

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -3332,6 +3332,74 @@ sFolderSpec EWSContext::resolveFolder(const sMessageEntryId& eid) const
 }
 
 /**
+ * @brief      Find a contact photo by email address in the given store's
+ *             default Contacts folder
+ *
+ * @param      dir    Home directory of the mailbox whose Contacts folder to search
+ * @param      email  Email address to match against Email1/2/3
+ *
+ * @return     Pointer to the photo's binary data, or nullptr if no matching
+ *             contact (or no photo on it) was found
+ *
+ * @note       Only searches the default Contacts folder, not any user-created
+ *             subfolders under it.
+ */
+const BINARY *EWSContext::findContactPhoto(const std::string &dir,
+    const std::string &email) const
+{
+	std::array<PROPERTY_NAME, 3> names = {NtEmailAddress1, NtEmailAddress2, NtEmailAddress3};
+	PROPNAME_ARRAY propNames = {static_cast<uint16_t>(names.size()), names.data()};
+	PROPID_ARRAY propIds = getNamedPropIds(dir, propNames);
+	if (propIds.size() != names.size())
+		return nullptr;
+
+	std::array<RESTRICTION_PROPERTY, 3> propertyRestrictions{};
+	std::array<RESTRICTION, 3> childRestrictions{};
+	TAGGED_PROPVAL matchValue{0, deconst(email.c_str())};
+	for (size_t i = 0; i < names.size(); ++i) {
+		auto tag = PROP_TAG(PT_UNICODE, propIds[i]);
+		propertyRestrictions[i].relop = RELOP_EQ;
+		propertyRestrictions[i].proptag = tag;
+		propertyRestrictions[i].propval.proptag = tag;
+		propertyRestrictions[i].propval.pvalue = matchValue.pvalue;
+		childRestrictions[i].rt = RES_PROPERTY;
+		childRestrictions[i].prop = &propertyRestrictions[i];
+	}
+	RESTRICTION_AND_OR orGroup = {static_cast<uint32_t>(childRestrictions.size()), childRestrictions.data()};
+	RESTRICTION restriction = {RES_OR, {&orGroup}};
+
+	uint32_t tableId = 0, rowCount = 0;
+	eid_t contactsFid(1, PRIVATE_FID_CONTACTS);
+	if (!m_plugin.exmdb.load_content_table(dir.c_str(), CP_ACP, contactsFid,
+	    nullptr, TABLE_FLAG_NONOTIFICATIONS, &restriction, nullptr, &tableId, &rowCount) ||
+	    rowCount == 0)
+		return nullptr;
+	auto cl_tbl = HX::make_scope_exit([&]() {
+		m_plugin.exmdb.unload_table(dir.c_str(), tableId);
+	});
+
+	static constexpr proptag_t midTag = PidTagMid;
+	TARRAY_SET rows{};
+	if (!m_plugin.exmdb.query_table(dir.c_str(), nullptr, CP_ACP, tableId,
+	    {&midTag, 1}, 0, 1, &rows) || rows.count == 0 || rows.pparray[0] == nullptr)
+		return nullptr;
+	auto mid = rows.pparray[0]->get<const eid_t>(PidTagMid);
+	if (mid == nullptr)
+		return nullptr;
+
+	MESSAGE_CONTENT *content = nullptr;
+	if (!m_plugin.exmdb.read_message(dir.c_str(), nullptr, CP_ACP, *mid, &content) ||
+	    content == nullptr || content->children.pattachments == nullptr)
+		return nullptr;
+	for (const auto &att : *content->children.pattachments) {
+		auto isPhoto = att.proplist.get<const uint8_t>(PR_ATTACHMENT_CONTACTPHOTO);
+		if (isPhoto != nullptr && *isPhoto)
+			return att.proplist.get<const BINARY>(PR_ATTACH_DATA_BIN);
+	}
+	return nullptr;
+}
+
+/**
  * @brief     Send message
  *
  * @param     dir      Home directory the message is associtated with

--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -3332,6 +3332,80 @@ sFolderSpec EWSContext::resolveFolder(const sMessageEntryId& eid) const
 }
 
 /**
+ * @brief      Find a contact photo by email address in the given store's
+ *             default Contacts folder
+ *
+ * GetUserPhoto only knows how to serve a local mailbox user's own
+ * organizational profile photo (a store-level property set via e.g.
+ * "gromox-mbop set-photo") - it has no notion of a personal contact's photo
+ * (a hidden PR_ATTACHMENT_CONTACTPHOTO attachment on an IPM.Contact item),
+ * even though that is by far the most common source of a photo for an
+ * external address someone has simply saved as a contact. This provides
+ * that fallback, scoped to the requesting user's own Contacts folder only -
+ * never another mailbox's, which would leak private data.
+ *
+ * @param      dir    Home directory of the mailbox whose Contacts folder to search
+ * @param      email  Email address to match against Email1/2/3
+ *
+ * @return     Pointer to the photo's binary data, or nullptr if no matching
+ *             contact (or no photo on it) was found
+ *
+ * @note       Only searches the default Contacts folder, not any user-created
+ *             subfolders under it.
+ */
+const BINARY *EWSContext::findContactPhoto(const std::string &dir, const std::string &email) const
+{
+	std::array<PROPERTY_NAME, 3> names{NtEmailAddress1, NtEmailAddress2, NtEmailAddress3};
+	PROPNAME_ARRAY propNames{static_cast<uint16_t>(names.size()), names.data()};
+	PROPID_ARRAY propIds = getNamedPropIds(dir, propNames);
+	if (propIds.size() != names.size())
+		return nullptr;
+
+	std::array<RESTRICTION_PROPERTY, 3> propertyRestrictions{};
+	std::array<RESTRICTION, 3> childRestrictions{};
+	TAGGED_PROPVAL matchValue{0, deconst(email.c_str())};
+	for (size_t i = 0; i < names.size(); ++i) {
+		auto tag = PROP_TAG(PT_UNICODE, propIds[i]);
+		propertyRestrictions[i].relop = RELOP_EQ;
+		propertyRestrictions[i].proptag = tag;
+		propertyRestrictions[i].propval.proptag = tag;
+		propertyRestrictions[i].propval.pvalue = matchValue.pvalue;
+		childRestrictions[i].rt = RES_PROPERTY;
+		childRestrictions[i].prop = &propertyRestrictions[i];
+	}
+	RESTRICTION_AND_OR orGroup{static_cast<uint32_t>(childRestrictions.size()), childRestrictions.data()};
+	RESTRICTION restriction{RES_OR, {&orGroup}};
+
+	uint32_t tableId = 0, rowCount = 0;
+	uint64_t contactsFid = rop_util_make_eid_ex(1, PRIVATE_FID_CONTACTS);
+	if (!m_plugin.exmdb.load_content_table(dir.c_str(), CP_ACP, contactsFid,
+	    nullptr, TABLE_FLAG_NONOTIFICATIONS, &restriction, nullptr, &tableId, &rowCount) ||
+	    rowCount == 0)
+		return nullptr;
+	auto cl_tbl = HX::make_scope_exit([&]() { m_plugin.exmdb.unload_table(dir.c_str(), tableId); });
+
+	static constexpr proptag_t midTag = PidTagMid;
+	TARRAY_SET rows{};
+	if (!m_plugin.exmdb.query_table(dir.c_str(), nullptr, CP_ACP, tableId,
+	    {&midTag, 1}, 0, 1, &rows) || rows.count == 0 || rows.pparray[0] == nullptr)
+		return nullptr;
+	auto mid = rows.pparray[0]->get<const uint64_t>(PidTagMid);
+	if (mid == nullptr)
+		return nullptr;
+
+	MESSAGE_CONTENT *content = nullptr;
+	if (!m_plugin.exmdb.read_message(dir.c_str(), nullptr, CP_ACP, *mid, &content) ||
+	    content == nullptr || content->children.pattachments == nullptr)
+		return nullptr;
+	for (const auto &att : *content->children.pattachments) {
+		auto isPhoto = att.proplist.get<const uint8_t>(PR_ATTACHMENT_CONTACTPHOTO);
+		if (isPhoto != nullptr && *isPhoto)
+			return att.proplist.get<const BINARY>(PR_ATTACH_DATA_BIN);
+	}
+	return nullptr;
+}
+
+/**
  * @brief     Send message
  *
  * @param     dir      Home directory the message is associtated with

--- a/exch/ews/ews.hpp
+++ b/exch/ews/ews.hpp
@@ -335,6 +335,7 @@ class EWSContext {
 	Structures::sFolderSpec resolveFolder(const Structures::tFolderId&) const;
 	Structures::sFolderSpec resolveFolder(const Structures::sFolderId&) const;
 	Structures::sFolderSpec resolveFolder(const Structures::sMessageEntryId&) const;
+	const BINARY *findContactPhoto(const std::string &dir, const std::string &email) const;
 	void send(const std::string &dir, uint64_t log_msg_id, const MESSAGE_CONTENT &) const;
 	void sendMeetingCancellation(const std::string&, const Structures::sMessageEntryId&, const Structures::sFolderSpec&, bool) const;
 	void sendMeetingResponse(const Structures::tItemId&, const MESSAGE_CONTENT&) const;

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -320,10 +320,27 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(base.get(), mid);
 				tPersona persona;
 				std::string val;
+				/*
+				 * Outlook Mac silently discards personas with
+				 * no PersonaType, even when DisplayName/
+				 * EmailAddress are populated - it has no way
+				 * to classify the suggestion, so it never
+				 * offers it in the autocomplete list.
+				 */
+				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
-				if (node.fetch_prop(PR_SMTP_ADDRESS, val) == ecSuccess)
-					persona.EmailAddress = std::move(val);
+				/*
+				 * PR_SMTP_ADDRESS is never present in the
+				 * ab_tree node's generic propvals map (unlike
+				 * ResolveNames, which correctly uses this
+				 * dedicated accessor) - fetch_prop() here
+				 * always missed, leaving personas with no
+				 * usable address for Outlook to autocomplete.
+				 */
+				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
+				    email != nullptr && *email != '\0')
+					persona.EmailAddress = email;
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -18,6 +18,7 @@
 #include <gromox/eid_array.hpp>
 #include <gromox/element_data.hpp>
 #include <gromox/fileio.h>
+#include <gromox/json.hpp>
 #include <gromox/mapitags.hpp>
 #include <gromox/mapidefs.h>
 #include <gromox/mysql_adaptor.hpp>
@@ -295,6 +296,90 @@ void process(mConvertIdRequest &&request, XMLElement *response, EWSContext &ctx)
 }
 
 /**
+ * @brief      Search grommunio-web's recipient history for FindPeople matches
+ *
+ * FindPeople's QuerySources typically ask for both "Directory" (the ab_tree
+ * GAL, handled by the caller) and "Mailbox" - people the user has actually
+ * corresponded with, regardless of whether they're in any directory. gromox
+ * itself doesn't track this for EWS, but grommunio-web already does: it
+ * maintains PR_EC_RECIPIENT_HISTORY_JSON (named property
+ * "websettings_recipienthistory" under PSETID_Gromox on the store) as a JSON
+ * blob of {display_name, smtp_address, count, last_used} updated whenever the
+ * user sends mail *via the webapp*. Reusing it here means Outlook's
+ * autocomplete benefits from the exact same history the webapp already
+ * builds - it just never gets contributed to by non-webapp sends.
+ */
+static void findpeople_search_recipient_history(const EWSContext &ctx,
+    const std::string &query, std::vector<tPersona> &out) try
+{
+	const char *user = znul(ctx.auth_info().username);
+	std::string dir = ctx.get_maildir(user);
+	PROPERTY_NAME pn = {MNID_STRING, PSETID_Gromox, 0, deconst("websettings_recipienthistory")};
+	PROPNAME_ARRAY propNames{1, &pn};
+	PROPID_ARRAY propIds = ctx.getNamedPropIds(dir, propNames);
+	if (propIds.size() != 1)
+		return;
+	const proptag_t tag = PROP_TAG(PT_UNICODE, propIds[0]);
+	TPROPVAL_ARRAY props;
+	if (!ctx.plugin().exmdb.get_store_properties(dir.c_str(), CP_ACP, {&tag, 1}, &props))
+		return;
+	auto json_str = props.get<const char>(tag);
+	if (json_str == nullptr || *json_str == '\0')
+		return;
+	Json::Value root;
+	if (!gromox::str_to_json(json_str, root) || !root.isMember("recipients"))
+		return;
+	auto tolower_str = [](std::string s) {
+		std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+		return s;
+	};
+	auto needle = tolower_str(query);
+	for (const auto &entry : root["recipients"]) {
+		auto name = entry.get("display_name", "").asString();
+		auto email = entry.get("smtp_address", "").asString();
+		if (email.empty())
+			continue;
+		if (tolower_str(name).find(needle) == std::string::npos &&
+		    tolower_str(email).find(needle) == std::string::npos)
+			continue;
+		tPersona persona;
+		persona.PersonaType = "Person";
+		if (!name.empty()) {
+			persona.DisplayName = name;
+			/*
+			 * Outlook Mac's FindPeople request explicitly asks for
+			 * persona:GivenName/persona:Surname (AdditionalProperties)
+			 * - a real Exchange capture always includes both, even
+			 * for a simple two-word display name. Leaving them unset
+			 * (as this recipient-history path did before) may cause
+			 * Outlook to silently drop the whole persona since it
+			 * asked for fields that never show up in the response.
+			 */
+			auto space = name.find(' ');
+			if (space != std::string::npos) {
+				persona.GivenName = name.substr(0, space);
+				persona.Surname = name.substr(space + 1);
+			} else {
+				persona.GivenName = name;
+			}
+		}
+		tEmailAddressType addr;
+		addr.Name = persona.DisplayName;
+		addr.EmailAddress = email;
+		addr.RoutingType = "SMTP";
+		addr.MailboxType = Enum::Mailbox;
+		persona.EmailAddress = std::move(addr);
+		tPersonaId pid;
+		pid.Id = base64_encode(email);
+		persona.PersonaId = std::move(pid);
+		persona.RelevanceScore = entry.get("count", 1).asUInt();
+		out.emplace_back(std::move(persona));
+	}
+} catch (const std::exception &e) {
+	mlog(LV_ERR, "findpeople_search_recipient_history: %s", e.what());
+}
+
+/**
  * @brief      Process FindPeople
  *
  * @param      request   Request data
@@ -306,7 +391,7 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 	response->SetName("m:FindPeopleResponse");
 
 	mFindPeopleResponse data;
-	auto &msg = data.ResponseMessages.emplace_back();
+	auto &msg = data;
 	const char *user = znul(ctx.auth_info().username);
 	const char *at = strchr(user, '@');
 	std::string domain = at ? at + 1 : user;
@@ -329,7 +414,11 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				 */
 				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
-					persona.DisplayName = std::move(val);
+					persona.DisplayName = val;
+				if (node.fetch_prop(PR_GIVEN_NAME, val) == ecSuccess)
+					persona.GivenName = std::move(val);
+				if (node.fetch_prop(PR_SURNAME, val) == ecSuccess)
+					persona.Surname = std::move(val);
 				/*
 				 * PR_SMTP_ADDRESS is never present in the
 				 * ab_tree node's generic propvals map (unlike
@@ -337,10 +426,34 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				 * dedicated accessor) - fetch_prop() here
 				 * always missed, leaving personas with no
 				 * usable address for Outlook to autocomplete.
+				 * Also: EmailAddress is a nested Mailbox-shaped
+				 * type (Name/EmailAddress/RoutingType/
+				 * MailboxType), not a flat string - a real
+				 * Exchange FindPeople response capture showed
+				 * Outlook expects this exact shape, and rejects
+				 * (silently, still "not found") a flat string.
 				 */
 				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
-				    email != nullptr && *email != '\0')
-					persona.EmailAddress = email;
+				    email != nullptr && *email != '\0') {
+					tEmailAddressType addr;
+					addr.Name = persona.DisplayName;
+					addr.EmailAddress = email;
+					addr.RoutingType = "SMTP";
+					addr.MailboxType = Enum::Mailbox;
+					persona.EmailAddress = std::move(addr);
+					/*
+					 * Real Exchange also always includes a
+					 * PersonaId - not a real MAPI EntryID
+					 * here, just a stable opaque handle
+					 * derived from the address, enough for
+					 * Outlook to accept the entry as
+					 * resolvable/insertable.
+					 */
+					tPersonaId pid;
+					pid.Id = base64_encode(email);
+					persona.PersonaId = std::move(pid);
+					persona.RelevanceScore = UINT32_MAX;
+				}
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)
@@ -357,16 +470,53 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				    persona.Title || persona.Nickname ||
 				    persona.BusinessPhoneNumber ||
 				    persona.MobilePhoneNumber ||
-				    persona.HomeAddress || persona.Comment)
-					msg.People.emplace().emplace_back(std::move(persona));
+				    persona.HomeAddress || persona.Comment) {
+					if (!msg.People)
+						msg.People.emplace();
+					msg.People->emplace_back(std::move(persona));
+				}
 			}
-			if (msg.People)
-				msg.TotalNumberOfPeopleInView = msg.People->size();
+		}
+
+		/*
+		 * Merge in "Mailbox" source results (people actually emailed
+		 * before, not necessarily in the directory) - see
+		 * findpeople_search_recipient_history() above. Dedup against
+		 * what ab_tree already found, by SMTP address.
+		 */
+		std::vector<tPersona> history;
+		findpeople_search_recipient_history(ctx, request.QueryString, history);
+		if (!history.empty()) {
+			if (!msg.People)
+				msg.People.emplace();
+			auto &people = *msg.People;
+			for (auto &persona : history) {
+				const std::string *addr = persona.EmailAddress ? &*persona.EmailAddress->EmailAddress : nullptr;
+				bool dup = addr && std::any_of(people.begin(), people.end(),
+				           [&](const tPersona &p) {
+				                   return p.EmailAddress && p.EmailAddress->EmailAddress &&
+				                          strcasecmp(p.EmailAddress->EmailAddress->c_str(), addr->c_str()) == 0;
+				           });
+				if (!dup)
+					people.emplace_back(std::move(persona));
+			}
+		}
+		if (msg.People) {
+			msg.TotalNumberOfPeopleInView = msg.People->size();
+			/*
+			 * Outlook Mac's autocomplete always requests a paged
+			 * view (IndexedPageItemView) - a real Exchange capture
+			 * showed it always includes FirstMatchingRowIndex/
+			 * FirstLoadedRowIndex alongside TotalNumberOfPeopleInView,
+			 * even for a single-page result. We don't implement real
+			 * paging, so both are always the start of (and only) page.
+			 */
+			msg.FirstMatchingRowIndex = 0;
+			msg.FirstLoadedRowIndex = 0;
 		}
 	} catch (const EWSError &err) {
-		data.ResponseMessages.clear();
-		data.ResponseMessages.emplace_back(err);
-		data.serialize(response);
+		mFindPeopleResponse errdata(err);
+		errdata.serialize(response);
 		return;
 	}
 
@@ -398,15 +548,30 @@ void process(mGetPersonaRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(it);
 				if (node.hidden() & AB_HIDE_RESOLVE)
 					continue;
+				/*
+				 * PR_SMTP_ADDRESS is never present in the
+				 * ab_tree node's generic propvals map - same
+				 * issue as FindPeople above, but here it meant
+				 * this match check never succeeded for anyone.
+				 */
+				auto email = node.user_info(ab_tree::userinfo::mail_address);
+				if (email == nullptr || *email == '\0' ||
+				    strcasecmp(email, target.c_str()) != 0)
+					continue;
 				std::string val;
-				if (node.fetch_prop(PR_SMTP_ADDRESS, val) != ecSuccess)
-					continue;
-				if (strcasecmp(val.c_str(), target.c_str()) != 0)
-					continue;
 				tPersona persona;
-				persona.EmailAddress = std::move(val);
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
-					persona.DisplayName = std::move(val);
+					persona.DisplayName = val;
+				tEmailAddressType addr;
+				addr.Name = persona.DisplayName;
+				addr.EmailAddress = email;
+				addr.RoutingType = "SMTP";
+				addr.MailboxType = Enum::Mailbox;
+				persona.EmailAddress = std::move(addr);
+				tPersonaId pid;
+				pid.Id = base64_encode(email);
+				persona.PersonaId = std::move(pid);
+				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -379,6 +379,109 @@ static void findpeople_search_recipient_history(const EWSContext &ctx,
 }
 
 /**
+ * @brief      Search the requesting user's own Contacts folder for FindPeople matches
+ *
+ * This function will match PR_DISPLAY_NAME or any of Email1/2/3EmailAddress by
+ * substring, using the same restriction as g-web's own ResolveNamesModule::
+ * searchContactsFolders()/getAmbigiousContactRestriction().
+ */
+static void findpeople_search_contacts(const EWSContext &ctx,
+    const std::string &query, std::vector<tPersona> &out) try
+{
+	if (query.empty())
+		return;
+	const char *user = znul(ctx.auth_info().username);
+	std::string dir = ctx.get_maildir(user);
+
+	std::array<PROPERTY_NAME, 3> names = {NtEmailAddress1, NtEmailAddress2, NtEmailAddress3};
+	PROPNAME_ARRAY propNames = {static_cast<uint16_t>(names.size()), names.data()};
+	PROPID_ARRAY propIds = ctx.getNamedPropIds(dir, propNames);
+	if (propIds.size() != names.size())
+		return;
+	std::array<proptag_t, 3> emailTags = {PROP_TAG(PT_UNICODE, propIds[0]),
+		PROP_TAG(PT_UNICODE, propIds[1]), PROP_TAG(PT_UNICODE, propIds[2])};
+
+	TAGGED_PROPVAL matchValue = {0, deconst(query.c_str())};
+	std::array<RESTRICTION_CONTENT, 4> contentRestrictions{};
+	std::array<RESTRICTION, 4> childRestrictions{};
+	contentRestrictions[0].fuzzy_level = FL_SUBSTRING | FL_IGNORECASE;
+	contentRestrictions[0].proptag = PR_DISPLAY_NAME;
+	contentRestrictions[0].propval.proptag = PR_DISPLAY_NAME;
+	contentRestrictions[0].propval.pvalue = matchValue.pvalue;
+	childRestrictions[0].rt = RES_CONTENT;
+	childRestrictions[0].cont = &contentRestrictions[0];
+	for (size_t i = 0; i < emailTags.size(); ++i) {
+		auto &cr = contentRestrictions[i + 1];
+		cr.fuzzy_level = FL_SUBSTRING | FL_IGNORECASE;
+		cr.proptag = emailTags[i];
+		cr.propval.proptag = emailTags[i];
+		cr.propval.pvalue = matchValue.pvalue;
+		childRestrictions[i + 1].rt = RES_CONTENT;
+		childRestrictions[i + 1].cont = &cr;
+	}
+	RESTRICTION_AND_OR orGroup = {static_cast<uint32_t>(childRestrictions.size()), childRestrictions.data()};
+	RESTRICTION restriction = {RES_OR, {&orGroup}};
+
+	uint32_t tableId = 0, rowCount = 0;
+	eid_t contactsFid(1, PRIVATE_FID_CONTACTS);
+	if (!ctx.plugin().exmdb.load_content_table(dir.c_str(), CP_ACP,
+	    contactsFid, nullptr, TABLE_FLAG_NONOTIFICATIONS, &restriction,
+	    nullptr, &tableId, &rowCount) || rowCount == 0)
+		return;
+	auto cl_tbl = HX::make_scope_exit([&]() {
+		ctx.plugin().exmdb.unload_table(dir.c_str(), tableId);
+	});
+
+	static constexpr uint32_t maxResults = 50;
+	std::array<proptag_t, 4> cols = {PR_DISPLAY_NAME, emailTags[0], emailTags[1], emailTags[2]};
+	TARRAY_SET rows{};
+	if (!ctx.plugin().exmdb.query_table(dir.c_str(), nullptr, CP_ACP,
+	    tableId, cols, 0, std::min(rowCount, maxResults), &rows))
+		return;
+
+	for (const auto &row : rows) {
+		auto name = row.get<const char>(PR_DISPLAY_NAME);
+		const char *email = nullptr;
+		for (auto tag : emailTags) {
+			email = row.get<const char>(tag);
+			if (email != nullptr && *email != '\0')
+				break;
+		}
+		if (email == nullptr || *email == '\0')
+			continue;
+
+		std::string dispName = name != nullptr ? name : "";
+		tPersona persona;
+		persona.PersonaType = "Person";
+		if (!dispName.empty()) {
+			persona.DisplayName = dispName;
+			auto space = dispName.find(' ');
+			if (space != std::string::npos) {
+				persona.GivenName = dispName.substr(0, space);
+				persona.Surname = dispName.substr(space + 1);
+			} else {
+				persona.GivenName = dispName;
+			}
+		}
+
+		tEmailAddressType addr;
+		addr.Name = persona.DisplayName;
+		addr.EmailAddress = email;
+		addr.RoutingType  = "SMTP";
+		addr.MailboxType  = Enum::Mailbox;
+		persona.EmailAddress = std::move(addr);
+
+		tPersonaId pid;
+		pid.Id = base64_encode(email);
+		persona.PersonaId = std::move(pid);
+		persona.RelevanceScore = 1;
+		out.emplace_back(std::move(persona));
+	}
+} catch (const std::exception &e) {
+	mlog(LV_ERR, "%s: %s", __func__, e.what());
+}
+
+/**
  * @brief      Process FindPeople
  *
  * @param      request   Request data
@@ -465,6 +568,7 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 		/* Merge in "Mailbox" source results */
 		std::vector<tPersona> history;
 		findpeople_search_recipient_history(ctx, request.QueryString, history);
+		findpeople_search_contacts(ctx, request.QueryString, history);
 		if (!history.empty()) {
 			if (!msg.People)
 				msg.People.emplace();

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -2299,6 +2299,7 @@ void process(mGetUserPhotoRequest &&request, XMLElement *response, EWSContext &c
 	response->SetName("m:GetUserPhotoResponse");
 
 	mGetUserPhotoResponse data;
+	const BINARY *photodata = nullptr;
 
 	try {
 		std::string dir = ctx.get_maildir(request.Email);
@@ -2310,15 +2311,29 @@ void process(mGetUserPhotoRequest &&request, XMLElement *response, EWSContext &c
 		const proptag_t tag = PROP_TAG(PT_BINARY, propIds[0]);
 		TPROPVAL_ARRAY props;
 		ctx.plugin().exmdb.get_store_properties(dir.c_str(), CP_ACP, {&tag, 1}, &props);
-		auto photodata = props.get<const BINARY>(tag);
-		if (photodata && photodata->cb)
-			data.PictureData = photodata;
-		else
-			ctx.code(http_status::not_found);
+		photodata = props.get<const BINARY>(tag);
 	} catch (const std::exception &err) {
-		ctx.code(http_status::not_found);
-		mlog(LV_WARN, "[ews#%d] Failed to load user photo: %s", ctx.context_id(), err.what());
+		mlog(LV_WARN, "[ews#%d] Failed to load organizational user photo: %s", ctx.context_id(), err.what());
 	}
+
+	if (photodata == nullptr || photodata->cb == 0) {
+		/*
+		 * Not a local mailbox user (or one without an org photo set) -
+		 * fall back to the requesting user's own saved contact for this
+		 * address, if any (see EWSContext::findContactPhoto).
+		 */
+		try {
+			std::string ownDir = ctx.get_maildir(ctx.auth_info().username);
+			photodata = ctx.findContactPhoto(ownDir, request.Email);
+		} catch (const std::exception &err) {
+			mlog(LV_WARN, "[ews#%d] Failed to load contact photo: %s", ctx.context_id(), err.what());
+		}
+	}
+
+	if (photodata && photodata->cb)
+		data.PictureData = photodata;
+	else
+		ctx.code(http_status::not_found);
 	data.success();
 	data.serialize(response);
 }

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -330,8 +330,9 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
-				if (node.fetch_prop(PR_SMTP_ADDRESS, val) == ecSuccess)
-					persona.EmailAddress = std::move(val);
+				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
+				    email != nullptr && *email != '\0')
+					persona.EmailAddress = email;
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -349,8 +349,11 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				    persona.Title || persona.Nickname ||
 				    persona.BusinessPhoneNumber ||
 				    persona.MobilePhoneNumber ||
-				    persona.HomeAddress || persona.Comment)
-					msg.People.emplace().emplace_back(std::move(persona));
+				    persona.HomeAddress || persona.Comment) {
+					if (!msg.People)
+						msg.People.emplace();
+					msg.People->emplace_back(std::move(persona));
+				}
 			}
 			if (msg.People)
 				msg.TotalNumberOfPeopleInView = msg.People->size();

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -2325,6 +2325,7 @@ void process(mGetUserPhotoRequest &&request, XMLElement *response, EWSContext &c
 	response->SetName("m:GetUserPhotoResponse");
 
 	mGetUserPhotoResponse data;
+	const BINARY *photodata = nullptr;
 
 	try {
 		std::string dir = ctx.get_maildir(request.Email);
@@ -2336,15 +2337,29 @@ void process(mGetUserPhotoRequest &&request, XMLElement *response, EWSContext &c
 		const proptag_t tag = PROP_TAG(PT_BINARY, propIds[0]);
 		TPROPVAL_ARRAY props;
 		ctx.plugin().exmdb.get_store_properties(dir.c_str(), CP_ACP, {&tag, 1}, &props);
-		auto photodata = props.get<const BINARY>(tag);
-		if (photodata && photodata->cb)
-			data.PictureData = photodata;
-		else
-			ctx.code(http_status::not_found);
+		photodata = props.get<const BINARY>(tag);
 	} catch (const std::exception &err) {
-		ctx.code(http_status::not_found);
-		mlog(LV_WARN, "[ews#%d] Failed to load user photo: %s", ctx.context_id(), err.what());
+		mlog(LV_WARN, "[ews#%d] Failed to load organizational user photo: %s", ctx.context_id(), err.what());
 	}
+
+	if (photodata == nullptr || photodata->cb == 0) {
+		/*
+		 * Not a local mailbox user (or one without an org photo set) -
+		 * fall back to the requesting user's own saved contact for this
+		 * address, if any (see EWSContext::findContactPhoto).
+		 */
+		try {
+			std::string ownDir = ctx.get_maildir(ctx.auth_info().username);
+			photodata = ctx.findContactPhoto(ownDir, request.Email);
+		} catch (const std::exception &err) {
+			mlog(LV_WARN, "[ews#%d] Failed to load contact photo: %s", ctx.context_id(), err.what());
+		}
+	}
+
+	if (photodata && photodata->cb)
+		data.PictureData = photodata;
+	else
+		ctx.code(http_status::not_found);
 	data.success();
 	data.serialize(response);
 }

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -18,6 +18,7 @@
 #include <gromox/eid_array.hpp>
 #include <gromox/element_data.hpp>
 #include <gromox/fileio.h>
+#include <gromox/json.hpp>
 #include <gromox/mapitags.hpp>
 #include <gromox/mapidefs.h>
 #include <gromox/mysql_adaptor.hpp>
@@ -295,6 +296,89 @@ void process(mConvertIdRequest &&request, XMLElement *response, EWSContext &ctx)
 }
 
 /**
+ * @brief      Search grommunio-web's recipient history for FindPeople matches
+ *
+ * FindPeople's QuerySources typically ask for both "Directory", referring the
+ * ab_tree GAL and handled by the caller, and "Mailbox", referring to people
+ * the user has actually corresponded with, regardless of whether they are in
+ * any directory. Gromox itself does not track recently-used recipients.
+ *
+ * g-web maintains PSETID_Gromox:websettings_recipienthistory as a JSON blob of
+ * {display_name, smtp_address, count, last_used} entries, updated whenever the
+ * user sends mail. Reusing it here means Outlook's autocomplete benefits from
+ * the exact same history that g-web webapp already builds, it just never gets
+ * contributed to by non-gweb send actions.
+ */
+static void findpeople_search_recipient_history(const EWSContext &ctx,
+    const std::string &query, std::vector<tPersona> &out) try
+{
+	const char *user = znul(ctx.auth_info().username);
+	std::string dir = ctx.get_maildir(user);
+	PROPERTY_NAME pn = {MNID_STRING, PSETID_Gromox, 0, deconst("websettings_recipienthistory")};
+	PROPNAME_ARRAY propNames{1, &pn};
+	PROPID_ARRAY propIds = ctx.getNamedPropIds(dir, propNames);
+	if (propIds.size() != 1)
+		return;
+	const proptag_t tag = PROP_TAG(PT_UNICODE, propIds[0]);
+	TPROPVAL_ARRAY props;
+	if (!ctx.plugin().exmdb.get_store_properties(dir.c_str(), CP_ACP, {&tag, 1}, &props))
+		return;
+	auto json_str = props.get<const char>(tag);
+	if (json_str == nullptr || *json_str == '\0')
+		return;
+	Json::Value root;
+	if (!gromox::str_to_json(json_str, root) || !root.isMember("recipients"))
+		return;
+
+	for (const auto &entry : root["recipients"]) {
+		auto name  = entry.get("display_name", "").asString();
+		auto email = entry.get("smtp_address", "").asString();
+		if (email.empty())
+			continue;
+		if (strcasestr(name.c_str(), query.c_str()) == nullptr &&
+		    strcasestr(email.c_str(), query.c_str()) == nullptr)
+			continue;
+
+		tPersona persona;
+		persona.PersonaType = "Person";
+		if (!name.empty()) {
+			persona.DisplayName = name;
+			/*
+			 * Outlook Mac's FindPeople request explicitly asks for
+			 * persona:GivenName/persona:Surname
+			 * (AdditionalProperties). Exchange always sends both,
+			 * even for a simple two-word display name. Leaving
+			 * them unset might cause Outlook to silently drop the
+			 * whole persona since it asked for fields that never
+			 * show up in the response.
+			 */
+			auto space = name.find(' ');
+			if (space != std::string::npos) {
+				persona.GivenName = name.substr(0, space);
+				persona.Surname = name.substr(space + 1);
+			} else {
+				persona.GivenName = name;
+			}
+		}
+
+		tEmailAddressType addr;
+		addr.Name = persona.DisplayName;
+		addr.EmailAddress = email;
+		addr.RoutingType  = "SMTP";
+		addr.MailboxType  = Enum::Mailbox;
+		persona.EmailAddress = std::move(addr);
+
+		tPersonaId pid;
+		pid.Id = base64_encode(email);
+		persona.PersonaId = std::move(pid);
+		persona.RelevanceScore = entry.get("count", 1).asUInt();
+		out.emplace_back(std::move(persona));
+	}
+} catch (const std::exception &e) {
+	mlog(LV_ERR, "%s: %s", __func__, e.what());
+}
+
+/**
  * @brief      Process FindPeople
  *
  * @param      request   Request data
@@ -378,6 +462,24 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 			}
 		}
 
+		/* Merge in "Mailbox" source results */
+		std::vector<tPersona> history;
+		findpeople_search_recipient_history(ctx, request.QueryString, history);
+		if (!history.empty()) {
+			if (!msg.People)
+				msg.People.emplace();
+			auto &people = *msg.People;
+			for (auto &persona : history) {
+				const std::string *addr = persona.EmailAddress ? &*persona.EmailAddress->EmailAddress : nullptr;
+				bool dup = addr && std::any_of(people.begin(), people.end(),
+				           [&](const tPersona &p) {
+				                   return p.EmailAddress && p.EmailAddress->EmailAddress &&
+				                          strcasecmp(p.EmailAddress->EmailAddress->c_str(), addr->c_str()) == 0;
+				           });
+				if (!dup)
+					people.emplace_back(std::move(persona));
+			}
+		}
 		if (msg.People) {
 			msg.TotalNumberOfPeopleInView = msg.People->size();
 			/*

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -320,6 +320,14 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(base.get(), mid);
 				tPersona persona;
 				std::string val;
+				/*
+				 * Outlook Mac silently discards personas with
+				 * no PersonaType, even when DisplayName/
+				 * EmailAddress are populated - it has no way
+				 * to classify the suggestion, so it never
+				 * offers it in the autocomplete list.
+				 */
+				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
 				if (node.fetch_prop(PR_SMTP_ADDRESS, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -306,7 +306,7 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 	response->SetName("m:FindPeopleResponse");
 
 	mFindPeopleResponse data;
-	auto &msg = data.ResponseMessages.emplace_back();
+	auto &msg = data;
 	const char *user = znul(ctx.auth_info().username);
 	const char *at = strchr(user, '@');
 	std::string domain = at ? at + 1 : user;
@@ -330,9 +330,30 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
+				if (node.fetch_prop(PR_GIVEN_NAME, val) == ecSuccess)
+					persona.GivenName = std::move(val);
+				if (node.fetch_prop(PR_SURNAME, val) == ecSuccess)
+					persona.Surname = std::move(val);
 				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
-				    email != nullptr && *email != '\0')
-					persona.EmailAddress = email;
+				    email != nullptr && *email != '\0') {
+					tEmailAddressType addr;
+					addr.Name         = persona.DisplayName;
+					addr.EmailAddress = email;
+					addr.RoutingType  = "SMTP";
+					addr.MailboxType  = Enum::Mailbox;
+					persona.EmailAddress = std::move(addr);
+					/*
+					 * Exchange also always includes a PersonaId.
+					 * This will not be a real MAPI EntryID here,
+					 * just a stable opaque handle derived from the
+					 * address, enough for Outlook to accept the
+					 * entry as resolvable/insertable.
+					 */
+					tPersonaId pid;
+					pid.Id = base64_encode(email);
+					persona.PersonaId = std::move(pid);
+					persona.RelevanceScore = UINT32_MAX;
+				}
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)
@@ -355,13 +376,25 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 					msg.People->emplace_back(std::move(persona));
 				}
 			}
-			if (msg.People)
-				msg.TotalNumberOfPeopleInView = msg.People->size();
+		}
+
+		if (msg.People) {
+			msg.TotalNumberOfPeopleInView = msg.People->size();
+			/*
+			 * Outlook Mac's autocomplete always requests a paged
+			 * view (IndexedPageItemView). Capturing Exchange shows
+			 * EXC always includes FirstMatchingRowIndex/
+			 * FirstLoadedRowIndex alongside
+			 * TotalNumberOfPeopleInView, even for a single-page
+			 * result. We do not implement actual paging, so both
+			 * are always the start of (and only) page.
+			 */
+			msg.FirstMatchingRowIndex = 0;
+			msg.FirstLoadedRowIndex = 0;
 		}
 	} catch (const EWSError &err) {
-		data.ResponseMessages.clear();
-		data.ResponseMessages.emplace_back(err);
-		data.serialize(response);
+		mFindPeopleResponse errdata(err);
+		errdata.serialize(response);
 		return;
 	}
 
@@ -393,15 +426,24 @@ void process(mGetPersonaRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(it);
 				if (node.hidden() & AB_HIDE_RESOLVE)
 					continue;
+				auto email = node.user_info(ab_tree::userinfo::mail_address);
+				if (email == nullptr || *email == '\0' ||
+				    strcasecmp(email, target.c_str()) != 0)
+					continue;
 				std::string val;
-				if (node.fetch_prop(PR_SMTP_ADDRESS, val) != ecSuccess)
-					continue;
-				if (strcasecmp(val.c_str(), target.c_str()) != 0)
-					continue;
 				tPersona persona;
-				persona.EmailAddress = std::move(val);
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
+				tEmailAddressType addr;
+				addr.Name = persona.DisplayName;
+				addr.EmailAddress = email;
+				addr.RoutingType = "SMTP";
+				addr.MailboxType = Enum::Mailbox;
+				persona.EmailAddress = std::move(addr);
+				tPersonaId pid;
+				pid.Id = base64_encode(email);
+				persona.PersonaId = std::move(pid);
+				persona.PersonaType = "Person";
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -380,6 +380,112 @@ static void findpeople_search_recipient_history(const EWSContext &ctx,
 }
 
 /**
+ * @brief      Search the requesting user's own Contacts folder for FindPeople matches
+ *
+ * Neither the ab_tree/GAL lookup above nor
+ * findpeople_search_recipient_history() ever look at a personal contact
+ * unless that contact was also independently emailed via grommunio-web - a
+ * contact saved with a photo and full details but never actually mailed
+ * from the webapp was invisible to Outlook's autocomplete. Matches
+ * PR_DISPLAY_NAME or any of Email1/2/3EmailAddress by substring, the same
+ * restriction shape grommunio-web's own ResolveNamesModule::
+ * searchContactsFolders()/getAmbigiousContactRestriction() use for the
+ * equivalent lookup. Scoped to the requesting user's own default Contacts
+ * folder only, like EWSContext::findContactPhoto() - never another
+ * mailbox's.
+ */
+static void findpeople_search_contacts(const EWSContext &ctx,
+    const std::string &query, std::vector<tPersona> &out) try
+{
+	if (query.empty())
+		return;
+	const char *user = znul(ctx.auth_info().username);
+	std::string dir = ctx.get_maildir(user);
+
+	std::array<PROPERTY_NAME, 3> names{NtEmailAddress1, NtEmailAddress2, NtEmailAddress3};
+	PROPNAME_ARRAY propNames{static_cast<uint16_t>(names.size()), names.data()};
+	PROPID_ARRAY propIds = ctx.getNamedPropIds(dir, propNames);
+	if (propIds.size() != names.size())
+		return;
+	std::array<proptag_t, 3> emailTags{PROP_TAG(PT_UNICODE, propIds[0]),
+		PROP_TAG(PT_UNICODE, propIds[1]), PROP_TAG(PT_UNICODE, propIds[2])};
+
+	TAGGED_PROPVAL matchValue{0, deconst(query.c_str())};
+	std::array<RESTRICTION_CONTENT, 4> contentRestrictions{};
+	std::array<RESTRICTION, 4> childRestrictions{};
+	contentRestrictions[0].fuzzy_level = FL_SUBSTRING | FL_IGNORECASE;
+	contentRestrictions[0].proptag = PR_DISPLAY_NAME;
+	contentRestrictions[0].propval.proptag = PR_DISPLAY_NAME;
+	contentRestrictions[0].propval.pvalue = matchValue.pvalue;
+	childRestrictions[0].rt = RES_CONTENT;
+	childRestrictions[0].cont = &contentRestrictions[0];
+	for (size_t i = 0; i < emailTags.size(); ++i) {
+		auto &cr = contentRestrictions[i + 1];
+		cr.fuzzy_level = FL_SUBSTRING | FL_IGNORECASE;
+		cr.proptag = emailTags[i];
+		cr.propval.proptag = emailTags[i];
+		cr.propval.pvalue = matchValue.pvalue;
+		childRestrictions[i + 1].rt = RES_CONTENT;
+		childRestrictions[i + 1].cont = &cr;
+	}
+	RESTRICTION_AND_OR orGroup{static_cast<uint32_t>(childRestrictions.size()), childRestrictions.data()};
+	RESTRICTION restriction{RES_OR, {&orGroup}};
+
+	uint32_t tableId = 0, rowCount = 0;
+	uint64_t contactsFid = rop_util_make_eid_ex(1, PRIVATE_FID_CONTACTS);
+	if (!ctx.plugin().exmdb.load_content_table(dir.c_str(), CP_ACP, contactsFid,
+	    nullptr, TABLE_FLAG_NONOTIFICATIONS, &restriction, nullptr, &tableId, &rowCount) ||
+	    rowCount == 0)
+		return;
+	auto cl_tbl = HX::make_scope_exit([&]() { ctx.plugin().exmdb.unload_table(dir.c_str(), tableId); });
+
+	static constexpr uint32_t maxResults = 50;
+	std::array<proptag_t, 4> cols{PR_DISPLAY_NAME, emailTags[0], emailTags[1], emailTags[2]};
+	TARRAY_SET rows{};
+	if (!ctx.plugin().exmdb.query_table(dir.c_str(), nullptr, CP_ACP, tableId,
+	    cols, 0, std::min(rowCount, maxResults), &rows))
+		return;
+
+	for (const auto &row : rows) {
+		auto name = row.get<const char>(PR_DISPLAY_NAME);
+		const char *email = nullptr;
+		for (auto tag : emailTags) {
+			email = row.get<const char>(tag);
+			if (email != nullptr && *email != '\0')
+				break;
+		}
+		if (email == nullptr || *email == '\0')
+			continue;
+		std::string dispName = name != nullptr ? name : "";
+		tPersona persona;
+		persona.PersonaType = "Person";
+		if (!dispName.empty()) {
+			persona.DisplayName = dispName;
+			auto space = dispName.find(' ');
+			if (space != std::string::npos) {
+				persona.GivenName = dispName.substr(0, space);
+				persona.Surname = dispName.substr(space + 1);
+			} else {
+				persona.GivenName = dispName;
+			}
+		}
+		tEmailAddressType addr;
+		addr.Name = persona.DisplayName;
+		addr.EmailAddress = email;
+		addr.RoutingType = "SMTP";
+		addr.MailboxType = Enum::Mailbox;
+		persona.EmailAddress = std::move(addr);
+		tPersonaId pid;
+		pid.Id = base64_encode(email);
+		persona.PersonaId = std::move(pid);
+		persona.RelevanceScore = 1;
+		out.emplace_back(std::move(persona));
+	}
+} catch (const std::exception &e) {
+	mlog(LV_ERR, "findpeople_search_contacts: %s", e.what());
+}
+
+/**
  * @brief      Process FindPeople
  *
  * @param      request   Request data
@@ -486,6 +592,7 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 		 */
 		std::vector<tPersona> history;
 		findpeople_search_recipient_history(ctx, request.QueryString, history);
+		findpeople_search_contacts(ctx, request.QueryString, history);
 		if (!history.empty()) {
 			if (!msg.People)
 				msg.People.emplace();

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -521,8 +521,8 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 					persona.GivenName = std::move(val);
 				if (node.fetch_prop(PR_SURNAME, val) == ecSuccess)
 					persona.Surname = std::move(val);
-				if (auto email = node.user_info(ab_tree::userinfo::mail_address);
-				    email != nullptr && *email != '\0') {
+				std::string email;
+				if (node.fetch_prop(PR_SMTP_ADDRESS, email) == ecSuccess) {
 					tEmailAddressType addr;
 					addr.Name         = persona.DisplayName;
 					addr.EmailAddress = email;
@@ -537,7 +537,7 @@ void process(mFindPeopleRequest &&request, XMLElement *response, const EWSContex
 					 * entry as resolvable/insertable.
 					 */
 					tPersonaId pid;
-					pid.Id = base64_encode(email);
+					pid.Id = base64_encode(std::move(email));
 					persona.PersonaId = std::move(pid);
 					persona.RelevanceScore = UINT32_MAX;
 				}
@@ -632,24 +632,27 @@ void process(mGetPersonaRequest &&request, XMLElement *response, const EWSContex
 				ab_tree::ab_node node(it);
 				if (node.hidden() & AB_HIDE_RESOLVE)
 					continue;
-				auto email = node.user_info(ab_tree::userinfo::mail_address);
-				if (email == nullptr || *email == '\0' ||
-				    strcasecmp(email, target.c_str()) != 0)
+				std::string email;
+				if (node.fetch_prop(PR_SMTP_ADDRESS, email) != ecSuccess ||
+				    strcasecmp(email.c_str(), target.c_str()) != 0)
 					continue;
 				std::string val;
 				tPersona persona;
 				if (node.fetch_prop(PR_DISPLAY_NAME, val) == ecSuccess)
 					persona.DisplayName = std::move(val);
+
 				tEmailAddressType addr;
 				addr.Name = persona.DisplayName;
 				addr.EmailAddress = email;
-				addr.RoutingType = "SMTP";
-				addr.MailboxType = Enum::Mailbox;
+				addr.RoutingType  = "SMTP";
+				addr.MailboxType  = Enum::Mailbox;
 				persona.EmailAddress = std::move(addr);
+
 				tPersonaId pid;
-				pid.Id = base64_encode(email);
-				persona.PersonaId = std::move(pid);
+				pid.Id = base64_encode(std::move(email));
+				persona.PersonaId   = std::move(pid);
 				persona.PersonaType = "Person";
+
 				if (node.fetch_prop(PR_TITLE, val) == ecSuccess)
 					persona.Title = std::move(val);
 				if (node.fetch_prop(PR_NICKNAME, val) == ecSuccess)

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -1119,6 +1119,7 @@ void tImAddressDictionaryEntry::serialize(tinyxml2::XMLElement *xml) const
 
 void tPersona::serialize(XMLElement *xml) const
 {
+	XMLDUMPT(PersonaType);
 	XMLDUMPT(DisplayName);
 	XMLDUMPT(EmailAddress);
 	XMLDUMPT(Title);

--- a/exch/ews/serialization.cpp
+++ b/exch/ews/serialization.cpp
@@ -1117,10 +1117,18 @@ void tImAddressDictionaryEntry::serialize(tinyxml2::XMLElement *xml) const
 	XMLDUMPA(Key);
 }
 
+void tPersonaId::serialize(XMLElement *xml) const
+{
+	XMLDUMPA(Id);
+}
+
 void tPersona::serialize(XMLElement *xml) const
 {
+	XMLDUMPT(PersonaId);
 	XMLDUMPT(PersonaType);
 	XMLDUMPT(DisplayName);
+	XMLDUMPT(GivenName);
+	XMLDUMPT(Surname);
 	XMLDUMPT(EmailAddress);
 	XMLDUMPT(Title);
 	XMLDUMPT(Nickname);
@@ -1128,6 +1136,7 @@ void tPersona::serialize(XMLElement *xml) const
 	XMLDUMPT(MobilePhoneNumber);
 	XMLDUMPT(HomeAddress);
 	XMLDUMPT(Comment);
+	XMLDUMPT(RelevanceScore);
 }
 
 tPullSubscriptionRequest::tPullSubscriptionRequest(const tinyxml2::XMLElement *xml) :
@@ -2415,16 +2424,13 @@ mFindPeopleRequest::mFindPeopleRequest(const XMLElement *xml) :
 	XMLINIT(QueryString)
 {}
 
-void mFindPeopleResponseMessage::serialize(XMLElement *xml) const
+void mFindPeopleResponse::serialize(XMLElement *xml) const
 {
 	mResponseMessageType::serialize(xml);
 	XMLDUMPM(People);
 	XMLDUMPM(TotalNumberOfPeopleInView);
-}
-
-void mFindPeopleResponse::serialize(XMLElement *xml) const
-{
-	XMLDUMPM(ResponseMessages);
+	XMLDUMPM(FirstMatchingRowIndex);
+	XMLDUMPM(FirstLoadedRowIndex);
 }
 
 mGetPersonaRequest::mGetPersonaRequest(const XMLElement *xml) :

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -815,8 +815,8 @@ struct tPersona : public NS_EWS_Types {
 
 	void serialize(tinyxml2::XMLElement *) const;
 
-	std::optional<std::string> DisplayName, EmailAddress, Title, Nickname,
-		BusinessPhoneNumber, MobilePhoneNumber, HomeAddress, Comment;
+	std::optional<std::string> PersonaType, DisplayName, EmailAddress, Title,
+		Nickname, BusinessPhoneNumber, MobilePhoneNumber, HomeAddress, Comment;
 };
 
 /**

--- a/exch/ews/structures.hpp
+++ b/exch/ews/structures.hpp
@@ -808,6 +808,19 @@ struct tImAddressDictionaryEntry : public NS_EWS_Types {
 };
 
 /**
+ * Types.xsd:2128 (PersonaId, simplified - just enough for FindPeople to
+ * hand back an opaque, stable identifier; not a real MAPI EntryID like
+ * tBaseItemId)
+ */
+struct tPersonaId : public NS_EWS_Types {
+	static constexpr char NAME[] = "PersonaId";
+
+	void serialize(tinyxml2::XMLElement *) const;
+
+	std::string Id;
+};
+
+/**
  * Types.xsd:8508 (simplified)
  */
 struct tPersona : public NS_EWS_Types {
@@ -815,8 +828,12 @@ struct tPersona : public NS_EWS_Types {
 
 	void serialize(tinyxml2::XMLElement *) const;
 
-	std::optional<std::string> PersonaType, DisplayName, EmailAddress, Title,
+	std::optional<tPersonaId> PersonaId;
+	std::optional<std::string> PersonaType, DisplayName, GivenName, Surname;
+	std::optional<tEmailAddressType> EmailAddress;
+	std::optional<std::string> Title,
 		Nickname, BusinessPhoneNumber, MobilePhoneNumber, HomeAddress, Comment;
+	std::optional<uint32_t> RelevanceScore;
 };
 
 /**
@@ -4078,19 +4095,21 @@ struct mFindPeopleRequest {
 /**
  * Messages.xsd:2788 (simplified)
  */
-struct mFindPeopleResponseMessage : public mResponseMessageType {
-	static constexpr char NAME[] = "FindPeopleResponseMessage";
-
+/*
+ * Unlike most EWS operations, FindPeople's response is not wrapped in a
+ * ResponseMessages/FindPeopleResponseMessage batch envelope - a real
+ * Exchange capture showed ResponseClass sits directly on the
+ * FindPeopleResponse root element, with People/TotalNumberOfPeopleInView/
+ * FirstMatchingRowIndex/FirstLoadedRowIndex as direct children. Outlook
+ * Mac silently discarded every prior (structurally over-nested) response
+ * regardless of content correctness because of this.
+ */
+struct mFindPeopleResponse : public mResponseMessageType {
 	using mResponseMessageType::mResponseMessageType;
 
 	std::optional<std::vector<tPersona>> People;
 	std::optional<uint32_t> TotalNumberOfPeopleInView;
-
-	void serialize(tinyxml2::XMLElement *) const;
-};
-
-struct mFindPeopleResponse {
-	std::vector<mFindPeopleResponseMessage> ResponseMessages;
+	std::optional<uint32_t> FirstMatchingRowIndex, FirstLoadedRowIndex;
 
 	void serialize(tinyxml2::XMLElement *) const;
 };

--- a/exch/nsp/nsp_interface.cpp
+++ b/exch/nsp/nsp_interface.cpp
@@ -387,13 +387,7 @@ static ec_error_t nsp_interface_fetch_property(const ab_tree::ab_node &node,
 	case PR_ACCOUNT_A:
 	case PR_SMTP_ADDRESS:
 	case PR_SMTP_ADDRESS_A:
-		if (node_type == ab_tree::abnode_type::mlist)
-			node.mlist_info(&dn, nullptr, nullptr);
-		else if (node_type == ab_tree::abnode_type::user)
-			dn = znul(node.user_info(ab_tree::userinfo::mail_address));
-		else
-			return ecNotFound;
-		if (dn.empty())
+		if (node.fetch_prop(PR_SMTP_ADDRESS, dn) != ecSuccess)
 			return ecNotFound;
 		if (pprop == nullptr)
 			return ecSuccess;

--- a/exch/zcore/ab_tree.cpp
+++ b/exch/zcore/ab_tree.cpp
@@ -301,13 +301,7 @@ static BOOL ab_tree_fetch_node_property(const ab_tree::ab_node &pnode,
 	case PR_ACCOUNT:
 	case PR_SMTP_ADDRESS: {
 		std::string dn;
-		if (node_type == ab_tree::abnode_type::mlist)
-			pnode.mlist_info(&dn, nullptr, nullptr);
-		else if (node_type == ab_tree::abnode_type::user)
-			dn = znul(pnode.user_info(ab_tree::userinfo::mail_address));
-		else
-			return TRUE;
-		if (dn.empty())
+		if (pnode.fetch_prop(PR_SMTP_ADDRESS, dn) != ecSuccess)
 			return TRUE;
 		auto pvalue = common_util_dup(dn);
 		if (pvalue == nullptr)

--- a/lib/ab_tree.cpp
+++ b/lib/ab_tree.cpp
@@ -472,6 +472,25 @@ bool ab_base::exists(minid mid) const
  */
 ec_error_t ab_base::fetch_prop(minid mid, proptag_t tag, std::string &prop) const
 {
+	/*
+	 * Do not take these props from user_properties. They are just too
+	 * essential and disagreeing values could lead to confusion.
+	 */
+	if (tag == PR_SMTP_ADDRESS) {
+		if (type(mid) == abnode_type::mlist) {
+			std::string dn;
+			if (!mlist_info(mid, &dn, nullptr, nullptr) || dn.empty())
+				return ecNotFound;
+			prop = std::move(dn);
+			return ecSuccess;
+		}
+		auto addr = user_info(mid, userinfo::mail_address);
+		if (addr == nullptr || *addr == '\0')
+			return ecNotFound;
+		prop = addr;
+		return ecSuccess;
+	}
+
 	const sql_user *user = fetch_user(mid);
 	if (!user)
 		return ecNotFound;


### PR DESCRIPTION
Stacked on top of #270 (adds tPersona::PersonaId/RelevanceScore/GivenName/Surname this depends on, and findpeople_search_recipient_history() this is placed alongside) - GitHub cannot base a PR against another fork's branch, so this diff includes #270's two commits too; only the last two commits (`ews: fall back to a personal Contacts photo in GetUserPhoto` and `ews: search the requesting user's own Contacts folder in FindPeople`) are new here. Please review/merge #270 first, or let me know if you'd rather review these together.

Two related fixes making EWS aware of the requesting user's own personal Contacts folder, which neither GetUserPhoto nor FindPeople looked at before:

- `EWSContext::findContactPhoto()`: GetUserPhoto only ever served a local mailbox user's own organizational profile photo (a store-level named property). It had no notion of a personal contact's own photo (a hidden PR_ATTACHMENT_CONTACTPHOTO attachment on an IPM.Contact item) - the far more common real-world source of a photo for an external address someone has simply saved as a contact. This adds it as a fallback, scoped to the requesting user's own Contacts folder only.

- `findpeople_search_contacts()`: FindPeople only ever searched the ab_tree/GAL and grommunio-web's own recipient-history JSON blob (people the user has sent mail to via the webapp specifically). A real personal contact, saved with full details but never independently emailed through the webapp, was invisible to Outlook's autocomplete no matter how complete the contact card was. This adds a direct search of the requesting user's own Contacts folder, matching PR_DISPLAY_NAME or any of Email1/2/3EmailAddress by substring - the same restriction shape grommunio-web's own ResolveNamesModule::searchContactsFolders() uses for the equivalent lookup.

Both deployed to production and confirmed working live (contact photo shown in message list/reading pane; a personal contact never emailed via the webapp now correctly autocompletes in real Outlook).