### PR TITLE
ruleproc: drop stale per-occurrence items when the series is re-issued

### DIFF
--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -1451,6 +1451,28 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 {
 	auto &rq_prop = par.ctnt->proplist;
 	auto cal_fid  = rop_util_make_eid_ex(1, PRIVATE_FID_CALENDAR);
+	auto goid_tag = PROP_TAG(PT_BINARY, propids[l_goid]);
+	auto seq_tag  = PROP_TAG(PT_LONG, propids[l_appt_seq]);
+	auto goid     = rq_prop.get<const BINARY>(goid_tag);
+	auto basedate = mr_goid_instancedate(goid);
+
+	/*
+	 * An update for one occurrence of a series carries a
+	 * GlobalObjectId with the instance date embedded, which by
+	 * construction never equals the series master's. Only resource
+	 * calendars are maintained server-side here; for user mailboxes,
+	 * blob surgery is left to the recipient's client, just as for a
+	 * single-occurrence cancellation.
+	 *
+	 * Entering the occurrence as a standalone item instead would
+	 * duplicate it: the recipient's client folds the update into the
+	 * master as an exception, while the item entered here relates to
+	 * that master by nothing the client can reconcile, so the
+	 * occurrence stays visible twice.
+	 */
+	if (basedate != 0 && !policy.is_resource())
+		return ecSuccess;
+
 	/*
 	 * Locate any calendar item(s) previously entered for this meeting (same
 	 * PidLidGlobalObjectId); an update or reschedule carries the same GOID,
@@ -1458,9 +1480,6 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 	 */
 	std::vector<eid_t> existing;
 	{
-		auto goid_tag = PROP_TAG(PT_BINARY, propids[l_goid]);
-		auto goid = rq_prop.get<const BINARY>(goid_tag);
-		auto seq_tag  = PROP_TAG(PT_LONG, propids[l_appt_seq]);
 		std::vector<mr_calitem> items;
 		auto err = mr_find_cal_items(par, goid_tag, goid, seq_tag,
 		           goid_tag, items);
@@ -1507,7 +1526,6 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 		    nullptr, cal_fid, &ids, true /* hard */, &partial))
 			return ecRpcFailed;
 	}
-
 	/* Lookup conflict state */
 	bool res_in_use = false, response_allowed = false;
 	auto start_nt = rq_prop.get<uint64_t>(PROP_TAG(PT_SYSTIME, propids[l_start_whole]));

--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -1454,10 +1454,12 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 {
 	auto &rq_prop = par.ctnt->proplist;
 	auto cal_fid  = rop_util_make_eid_ex(1, PRIVATE_FID_CALENDAR);
-	auto goid_tag = PROP_TAG(PT_BINARY, propids[l_goid]);
-	auto seq_tag  = PROP_TAG(PT_LONG, propids[l_appt_seq]);
-	auto goid     = rq_prop.get<const BINARY>(goid_tag);
-	auto basedate = mr_goid_instancedate(goid);
+	auto goid_tag  = PROP_TAG(PT_BINARY, propids[l_goid]);
+	auto cgoid_tag = PROP_TAG(PT_BINARY, propids[l_cleangoid]);
+	auto seq_tag   = PROP_TAG(PT_LONG, propids[l_appt_seq]);
+	auto goid      = rq_prop.get<const BINARY>(goid_tag);
+	auto cgoid     = rq_prop.get<const BINARY>(cgoid_tag);
+	auto basedate  = mr_goid_instancedate(goid);
 
 	/*
 	 * An update for one occurrence of a series carries a
@@ -1477,22 +1479,43 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 		return ecSuccess;
 
 	/*
-	 * Locate any calendar item(s) previously entered for this meeting (same
-	 * PidLidGlobalObjectId); an update or reschedule carries the same GOID,
-	 * so these are the prior bookings the request supersedes.
+	 * Locate the calendar item(s) this request supersedes. An update or
+	 * reschedule of the series carries the same GOID as the master, but
+	 * standalone items entered earlier for individual occurrences carry an
+	 * instance date in theirs and would never match it, so for a series
+	 * match on CleanGlobalObjectId, which is shared by the master and all
+	 * of its occurrences. An occurrence update matches its own dated GOID,
+	 * which selects just that instance.
 	 */
 	std::vector<eid_t> existing;
 	{
+		auto match_tag = goid_tag;
+		auto match_val = goid;
+		if (basedate == 0 && cgoid != nullptr && cgoid->cb != 0) {
+			match_tag = cgoid_tag;
+			match_val = cgoid;
+		}
 		std::vector<mr_calitem> items;
-		auto err = mr_find_cal_items(par, goid_tag, goid, seq_tag,
+		auto err = mr_find_cal_items(par, match_tag, match_val, seq_tag,
 		           goid_tag, items);
 		if (err != ecSuccess)
 			return err;
 		/* Ignore stale out-of-order updates that predate what we already have. */
 		if (!items.empty()) {
+			/*
+			 * For a series, compare against the master's
+			 * sequence only: per-instance sequences run
+			 * independently per RECURRENCE-ID and can
+			 * exceed a series update's, which would
+			 * discard a valid update as stale.
+			 */
 			uint32_t newest_seq = 0;
-			for (const auto &e : items)
-				newest_seq = std::max(newest_seq, e.seq);
+			for (const auto &e : items) {
+				if (basedate == 0 && e.dated)
+					continue;
+				if (e.seq > newest_seq)
+					newest_seq = e.seq;
+			}
 			auto seq = rq_prop.get<const uint32_t>(seq_tag);
 			if (seq != nullptr && *seq < newest_seq)
 				return mr_mark_done(par);
@@ -1537,8 +1560,6 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 	 * not go on reporting both as busy afterwards. Reached for
 	 * resources only, per the note at the top of this function.
 	 */
-	auto cgoid_tag = PROP_TAG(PT_BINARY, propids[l_cleangoid]);
-	auto cgoid     = rq_prop.get<const BINARY>(cgoid_tag);
 	if (basedate != 0 && cgoid != nullptr && cgoid->cb != 0) {
 		auto seq = rq_prop.get<const uint32_t>(seq_tag);
 		std::vector<mr_calitem> masters;

--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -1446,6 +1446,9 @@ static ec_error_t mr_rewrite_cal_item(rxparam &par, eid_t cal_fid,
 	return err;
 }
 
+static ec_error_t mr_remove_occurrence(rxparam &, const PROPID_ARRAY &,
+	eid_t cal_fid, eid_t cal_mid, uint32_t basedate);
+
 static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
     const mr_policy &policy)
 {
@@ -1526,6 +1529,43 @@ static ec_error_t mr_do_request(rxparam &par, const PROPID_ARRAY &propids,
 		    nullptr, cal_fid, &ids, true /* hard */, &partial))
 			return ecRpcFailed;
 	}
+	/*
+	 * A moved occurrence still holds its original slot in the master's
+	 * recurrence blob. Punch it out before the free/busy check, for the
+	 * same reason the prior bookings are dropped first: the occurrence
+	 * must not clash with its own earlier slot, and the resource must
+	 * not go on reporting both as busy afterwards. Reached for
+	 * resources only, per the note at the top of this function.
+	 */
+	auto cgoid_tag = PROP_TAG(PT_BINARY, propids[l_cleangoid]);
+	auto cgoid     = rq_prop.get<const BINARY>(cgoid_tag);
+	if (basedate != 0 && cgoid != nullptr && cgoid->cb != 0) {
+		auto seq = rq_prop.get<const uint32_t>(seq_tag);
+		std::vector<mr_calitem> masters;
+		auto err = mr_find_cal_items(par, cgoid_tag, cgoid, seq_tag,
+		           goid_tag, masters);
+		if (err != ecSuccess)
+			return err;
+		for (const auto &e : masters) {
+			/* another instance's standalone item */
+			if (e.dated)
+				continue;
+			/*
+			 * With no standalone item for this instance, its
+			 * sequence lineage is the master's, so a master ahead
+			 * of the update means the series was re-issued after
+			 * the update was sent and the update is stale. Same
+			 * test as in mr_do_cancel.
+			 */
+			if (existing.empty() && seq != nullptr && e.seq > *seq)
+				continue;
+			err = mr_remove_occurrence(par, propids, cal_fid,
+			      e.mid, basedate);
+			if (err != ecSuccess)
+				return err;
+		}
+	}
+
 	/* Lookup conflict state */
 	bool res_in_use = false, response_allowed = false;
 	auto start_nt = rq_prop.get<uint64_t>(PROP_TAG(PT_SYSTIME, propids[l_start_whole]));


### PR DESCRIPTION
### Problem

With `lda_twostep_ruleproc` + `lda_mrautoproc` enabled, editing **one occurrence** of a recurring meeting gives every attendee a duplicate: the series still shows the occurrence at its original time, and a second, standalone appointment appears at the new time. The organizer is unaffected. Attendees whose client reconciles the redundant item (Outlook) mask it; those whose client does not (grommunio-web) see both.

For a **resource** mailbox the same defect shows up as a double booking: the room reports both the original and the new slot as busy, and only a cancellation of the whole series ever clears the old one.

### Cause

`mr_do_request` has no handling for single occurrences at all — no reference to an instance date, `PidLidIsException`, or occurrence removal. `mr_do_cancel` has all of it.

An update for one occurrence carries a `PidLidGlobalObjectId` with the instance date embedded, so it never equals the series master's. `mr_do_request` looks for the bookings it supersedes using that tag alone (`lib/ruleproc.cpp:1462-1466`), matches nothing, deletes nothing, and `mr_insert_to_cal` then writes the occurrence as a fresh standalone item — while the occurrence also remains in the master's recurrence blob.

### Changes

1. **`ruleproc: do not enter single-occurrence updates into user calendars`** — restricts server-side handling of single occurrences to resources, which is the policy `mr_do_cancel` already documents: *"Only resource calendars are maintained server-side here; for user mailboxes, blob surgery is left to the recipient's client."* The recipient's client folds the update into the master as an exception; an item entered here is related to that master by nothing either party can reconcile.
2. **`ruleproc: release a resource's original slot when an occurrence moves`** — punches the occurrence out of the master via the existing `mr_remove_occurrence()`, including the same stale-sequence guard `mr_do_cancel` uses. Done before the free/busy check, for the same reason the prior bookings are dropped first: a moved occurrence must not clash with its own earlier slot.
3. **`ruleproc: drop stale per-occurrence items when the series is re-issued`** — a standalone occurrence item keeps its own dated GOID, so a later update of the whole series never matched it and left it behind, double-booking a resource again. The series case now matches on `CleanGlobalObjectId`, which the master and all of its occurrences share, falling back to `PidLidGlobalObjectId` when a sender omits it. The sequence comparison skips the dated items while doing so, because per-instance sequences run independently per `RECURRENCE-ID` and can exceed a series update's.

`lib/ruleproc.cpp` only, +88/−9. Each commit builds independently.

### Verification

Compiled clean (openSUSE Leap 15.6, GCC 13) at all three commits, no new warnings.

Runtime-tested on a grommunio-in-Docker instance running this same gromox build, by swapping only `libgxs_ruleproc.so` between runs — each swap confirmed loaded by comparing the inode in `/proc/<delivery-pid>/maps` against the file on disk — and injecting the requests over SMTP as iCalendar. A plain non-recurring request served as a positive control to confirm mrautoproc was active at all, since neither directive is ever logged.

*User mailbox* — series request, then an update moving one occurrence 18:00 → 19:00:

| | calendar items |
|---|---|
| before | 3 (control, master, standalone at the new time with a dated GOID) |
| after | 1 (master only) |

*Resource* — same two messages, then `gromox-mbop get-freebusy` for the affected day:

| | original slot | new slot |
|---|---|---|
| before | busy | busy |
| after | free | busy |

*Resource, three-step case for change 3* — series (`SEQUENCE:0`), occurrence update (`SEQUENCE:9`, moved 18:00 → 19:00), then a series update (`SEQUENCE:1`, new subject):

| | calendar after | free/busy on the affected day |
|---|---|---|
| changes 1+2 only | new master **plus the stale standalone** | busy at 18:00 **and** 19:00 |
| all three changes | new master only | busy at 18:00 |
| all three, but without the dated-item filter in the sequence test | **old** master — the series update was silently discarded — plus the stale standalone | busy at 19:00 only |

That last row is why the sequence comparison has to skip dated items: with the stale occurrence item carrying `SEQUENCE:9`, a legitimate series update at `SEQUENCE:1` reads as stale and is dropped via `mr_mark_done()` with no error and no log line.

### Notes for review

- Change 1 narrows behaviour for a *user* mailbox that carries an explicit `PR_SCHDINFO_AUTO_ACCEPT_APPTS` or `PR_SCHDINFO_DISALLOW_OVERLAPPING_APPTS`: such a mailbox no longer auto-accepts or declines an occurrence update, and so sends no response for it. Happy to scope the early return to default-policy mailboxes instead.
- Change 3 also deletes top-level items with a dated GOID from *user* calendars. That should only ever remove what mrautoproc itself entered, since a client represents a moved occurrence as an attachment inside the master rather than as a separate item — but that is an assumption about clients, not something I verified beyond Outlook and grommunio-web.
- Punching the occurrence out before the conflict check means a *declined* occurrence move leaves the resource with neither booking. That matches what the function already does with `existing` one block earlier, so it is consistent rather than new.
- `mr_remove_occurrence` is forward-declared rather than moved above `mr_do_request`, to keep the diff to the change itself.
- Only the iCal import path was exercised at runtime; a MAPI/TNEF occurrence update takes the same GOID invariant but was not tested.
