### PR TITLE
ews: treat PidLidMeetingType as a bitmask

### DIFF
--- a/exch/ews/structures.cpp
+++ b/exch/ews/structures.cpp
@@ -215,15 +215,21 @@ Enum::LegacyFreeBusyType busystatus_to_legacyfb(uint32_t status)
 
 std::optional<Enum::MeetingRequestTypeType> meettype_to_mrtype(uint32_t meetingType)
 {
-	switch (meetingType) {
-	case mtgEmpty:         return Enum::None;
-	case mtgRequest:       return Enum::NewMeetingRequest;
-	case mtgFull:          return Enum::FullUpdate;
-	case mtgInfo:          return Enum::InformationalUpdate;
-	case mtgOutOfDate:     return Enum::Outdated;
-	case mtgDelegatorCopy: return Enum::PrincipalWantsCopy;
-	default:               return std::nullopt;
-	}
+	/* PidLidMeetingType is a bitmask (e.g. mtgRequest|mtgFull for new invites),
+	 * so it must be tested flag-wise rather than compared for equality. */
+	if (meetingType == mtgEmpty)
+		return Enum::None;
+	if (meetingType & mtgOutOfDate)
+		return Enum::Outdated;
+	if (meetingType & mtgDelegatorCopy)
+		return Enum::PrincipalWantsCopy;
+	if (meetingType & mtgRequest)
+		return Enum::NewMeetingRequest;
+	if (meetingType & mtgInfo)
+		return Enum::InformationalUpdate;
+	if (meetingType & mtgFull)
+		return Enum::FullUpdate;
+	return std::nullopt;
 }
 
 /**


### PR DESCRIPTION
### Problem

`oxcical_set_stateflags()` stores `PidLidMeetingType` as a bitmask. For an
incoming `METHOD:REQUEST` it writes `mtgRequest | mtgFull` (`0x00010001`):

https://github.com/grommunio/gromox/blob/master/lib/mapi/oxcical.cpp#L1107

`meettype_to_mrtype()` in `exch/ews/structures.cpp` however compares that value
for equality against the individual flags:

```c++
switch (meetingType) {
case mtgEmpty:         return Enum::None;
case mtgRequest:       return Enum::NewMeetingRequest;
case mtgFull:          return Enum::FullUpdate;
...
default:               return std::nullopt;
}
```

`0x00010001` matches no case, so the function returns `std::nullopt`.
`tMeetingRequestMessage::update()` then falls through to its default and
reports `MeetingRequestType` as `None`.

### Impact

Clients that use `MeetingRequestType` to tell an actionable invitation from an
ordinary message see `None`. In Outlook for Mac (16.111) the
Accept / Tentative / Decline buttons do not respond.

### Reproduction

Deliver an iMIP invitation (`Content-Type: text/calendar; method=REQUEST`) to a
mailbox, then ask for the property explicitly — a `Default` or `AllProperties`
shape does not pull the named property, so it has to be requested by FieldURI:

```xml
<m:ItemShape>
  <t:BaseShape>IdOnly</t:BaseShape>
  <t:AdditionalProperties>
    <t:FieldURI FieldURI="meetingRequest:MeetingRequestType"/>
  </t:AdditionalProperties>
</m:ItemShape>
```

The stored property is intact — requesting it as an extended field
(`PropertySetId=6ED8DA90-450B-101B-98DA-00AA003F1305 PropertyId=38`) returns
`65537`, i.e. `mtgRequest|mtgFull`.

Before this change `MeetingRequestType` came back as `None`; with it,
`NewMeetingRequest`.

### Change

Test the flags individually. The qualifying flags (`mtgOutOfDate`,
`mtgDelegatorCopy`) are checked before `mtgRequest` so that an outdated or
delegated request is still reported as such.

Built and tested on Debian 13 against a store reached over EWS.
