### PR TITLE
ews: keep streaming subscriptions alive across connections

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -626,7 +626,7 @@ EWSContext::~EWSContext()
 {
 	if (m_notify)
 		for (const auto &sub : m_notify->nct_subs)
-			unsubscribe(sub);
+			m_plugin.detachSubscription(sub, m_ctx_id);
 }
 
 /**

--- a/exch/ews/ews.cpp
+++ b/exch/ews/ews.cpp
@@ -1142,6 +1142,28 @@ void EWSPlugin::unlinkSubscription(detail::ContextKey ctx_id) const
 }
 
 /**
+ * @brief      Detach subscription from a context without cancelling it
+ *
+ * Streaming subscriptions outlive the individual GetStreamingEvents
+ * connection: the client reconnects with the same subscription id after
+ * each connection timeout. Only drop the link to the context, leaving the
+ * subscription in place until it times out or is explicitly unsubscribed.
+ *
+ * @param      id      Subscription to detach
+ * @param      ctx_id  Context the subscription was attached to
+ */
+void EWSPlugin::detachSubscription(const Structures::tSubscriptionId &id,
+    detail::ContextKey ctx_id) const
+{
+	auto mgr = get_submgr(id.tsub_rawkey, id.timeout);
+	if (mgr == nullptr)
+		return;
+	std::lock_guard subLock(mgr->lock);
+	if (mgr->waitingContext == ctx_id)
+		mgr->waitingContext = -1;
+}
+
+/**
  * @brief      Remove subscription
  *
  * If the supplied username does not match the username of the subscription,

--- a/exch/ews/ews.hpp
+++ b/exch/ews/ews.hpp
@@ -149,6 +149,7 @@ class EWSPlugin {
 	std::shared_ptr<SubManager> get_submgr(detail::SubscriptionKey, uint32_t) const;
 	std::string timestamp() const;
 	void unlinkSubscription(detail::ContextKey) const;
+	void detachSubscription(const Structures::tSubscriptionId &, detail::ContextKey) const;
 	bool unsubscribe(detail::SubscriptionKey, const char*) const;
 	void unsubscribe(const detail::ExmdbSubscriptionKey&) const;
 	void wakeContext(int, std::chrono::milliseconds) const;


### PR DESCRIPTION
### Problem

`~EWSContext()` cancels every subscription that was being streamed on the
context:

```c++
EWSContext::~EWSContext()
{
	if (m_notify)
		for (const auto &sub : m_notify->nct_subs)
			unsubscribe(sub);
}
```

A streaming subscription is meant to outlive the individual
`GetStreamingEvents` connection — clients reconnect with the same subscription
id once `ConnectionTimeout` elapses. Cancelling it on teardown means the first
reconnect is answered with `ErrorInvalidSubscription`.

Outlook for Mac does not re-subscribe on that error. It keeps polling the dead
id every 50 seconds for the lifetime of the account: no push notifications, and
the sync engine stops issuing any other request, so nothing arrives until the
account is removed and re-added.

### Reproduction

```
Subscribe                               -> SubscriptionId
GetStreamingEvents (connection closes)  -> NoError
GetStreamingEvents (same id)            -> ErrorInvalidSubscription
```

A subscription left idle without ever opening a streaming connection stays
valid, which is what isolates the teardown path rather than the expiry timer:

```
Subscribe -> wait 90s, no streaming -> GetStreamingEvents -> NoError
```

### Change

Detach the subscription from the context instead of cancelling it. The
subscription then lives until its own timeout expires or the client sends
`Unsubscribe`, and `waitingContext` is cleared so the next connection can
attach.

### Result

Eight consecutive streaming connections over ten minutes all return `NoError`,
and `NewMailEvent` / `CreatedEvent` / `ModifiedEvent` are delivered to the
client. Verified with Outlook for Mac 16.111: new mail now arrives without a
manual sync.

Built and tested on Debian 13.
