### PR TITLE
ews: do not synthesise meeting properties the shape did not load

### DIFF
--- a/exch/ews/structures.cpp
+++ b/exch/ews/structures.cpp
@@ -649,19 +649,19 @@ void sCalendarMeetingRequestCommon::update(const sShape &shape)
 		IntendedFreeBusyStatus.emplace(busystatus_to_legacyfb(*u32));
 	if ((u32 = shape.get<uint32_t>(NtBusyStatus)))
 		LegacyFreeBusyStatus.emplace(busystatus_to_legacyfb(*u32));
+	/*
+	 * Only report what the shape actually loaded. Synthesising values for
+	 * absent properties makes an id-only response (e.g. the item echoed
+	 * back by UpdateItem) claim the item is not a meeting, which clients
+	 * cache and act upon.
+	 */
 	if ((u32 = shape.get<uint32_t>(NtAppointmentStateFlags))) {
 		AppointmentState.emplace(*u32);
 		IsMeeting = *u32 & asfMeeting ? TRUE : false;
 		IsCancelled = *u32 & asfCanceled ? TRUE : false;
-	} else {
-		AppointmentState = 0;
-		IsMeeting = false;
-		IsCancelled = false;
 	}
 	if ((u32 = shape.get<uint32_t>(NtResponseStatus)))
 		MyResponseType.emplace(respstatus_to_resptype(*u32));
-	else
-		MyResponseType.emplace(Enum::Unknown);
 
 	const uint64_t* u64;
 	if ((u64 = shape.get<uint64_t>(NtAppointmentReplyTime)))
@@ -4415,8 +4415,6 @@ void tMeetingRequestMessage::update(const sShape& shape)
 		if (auto mapped = meettype_to_mrtype(meetingType))
 			MeetingRequestType.emplace(*mapped);
 	}
-	if (!MeetingRequestType)
-		MeetingRequestType.emplace(Enum::None);
 
 	if ((prop = shape.get(NtChangeHighlight))) {
 		const uint32_t flags = *static_cast<const uint32_t*>(prop->pvalue);


### PR DESCRIPTION
### Problem

`sCalendarMeetingRequestCommon::update()` substitutes hardcoded values when the
properties are not present in the shape:

```c++
if ((u32 = shape.get<uint32_t>(NtAppointmentStateFlags))) {
	AppointmentState.emplace(*u32);
	IsMeeting = *u32 & asfMeeting ? TRUE : false;
	IsCancelled = *u32 & asfCanceled ? TRUE : false;
} else {
	AppointmentState = 0;
	IsMeeting = false;
	IsCancelled = false;
}
if ((u32 = shape.get<uint32_t>(NtResponseStatus)))
	MyResponseType.emplace(respstatus_to_resptype(*u32));
else
	MyResponseType.emplace(Enum::Unknown);
```

`tMeetingRequestMessage::update()` does the same for `MeetingRequestType`.

"Property was not loaded" and "property is false" are not the same thing, and
the difference matters for responses built from an id-only shape.

### Impact

Outlook for Mac (16.111) marks an invitation as read when it is opened, which
sends:

```xml
<m:UpdateItem MessageDisposition="SaveOnly" ConflictResolution="AlwaysOverwrite">
  ... <t:FieldURI FieldURI="message:IsRead"/><t:IsRead>true</t:IsRead> ...
```

Gromox echoes the item back through `loadItem(..., idOnly)` and the synthesised
values turn that into:

```xml
<t:MeetingRequest>
  <t:IsMeeting>false</t:IsMeeting>
  <t:AppointmentState>0</t:AppointmentState>
  <t:MeetingRequestType>None</t:MeetingRequestType>
  <t:MyResponseType>Unknown</t:MyResponseType>
</t:MeetingRequest>
```

The client caches that and stops treating the item as an invitation: the
Accept / Tentative / Decline buttons are rendered but clicking them sends
nothing at all. The stored item is untouched — querying the same message with
the properties requested explicitly still reports `IsMeeting=true`,
`AppointmentState=3` and `MeetingRequestType=NewMeetingRequest`.

### Change

Leave the fields unset when their source properties were not loaded. Exchange
behaves the same way — its `UpdateItem` response carries only `ItemId` and
`ChangeKey`.

### Result

The `UpdateItem` response no longer contains `IsMeeting`, `IsCancelled`,
`AppointmentState`, `MeetingRequestType` or `MyResponseType`, and Outlook keeps
the correct cached state.

Built and tested on Debian 13.
