### PR TITLE
mda: fix access to uninitialized string

### DIFF
--- a/mda/exmdb_local/cache_queue.cpp
+++ b/mda/exmdb_local/cache_queue.cpp
@@ -373,6 +373,7 @@ static void *mdl_thrwork(void *arg)
 			delivery_status deliv_ret;
 			if (zlen == size) {
 				mlog(LV_WARN, "W-1591: garbage in %s; review and delete", temp_path.c_str());
+				temp_rcpt[0] = '\0';
 				deliv_ret = delivery_status::perm_fail;
 			} else {
 				pcontext->ctrl.rcpt.clear();


### PR DESCRIPTION
Fixing coverity issue 1527671 - temp_rcpt remained unitialized in fail case
