### PR TITLE
ruleproc: drop named properties the target store would not name

### DIFF
--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -282,9 +282,33 @@ static void rx_npid_collect(const MESSAGE_CONTENT &ctnt, std::set<uint16_t> &m)
 	}
 }
 
-static void rx_npid_transform(TPROPVAL_ARRAY &props,
+/**
+ * Rewrite named property ids from the source store's numbering into @dst's,
+ * dropping values @dst would not name, and return how many were dropped.
+ *
+ * A @dst entry of 0 means the target store does not have that name and did not
+ * create it (e.g. it is at MAXIMUM_PROPNAME_NUMBER); get_named_propids reports
+ * this per entry while succeeding overall. Neither id is usable in the target
+ * store: 0 is not a named property, and the source id there denotes an
+ * unrelated one.
+ *
+ * Removal precedes the rewrite: erase() matches whole proptags and removes the
+ * first match only, so a rewritten tag can collide with one still queued for
+ * removal.
+ */
+static size_t rx_npid_transform(TPROPVAL_ARRAY &props,
     const std::vector<uint16_t> &src, const PROPID_ARRAY &dst)
 {
+	std::vector<proptag_t> drop;
+	for (const auto &pv : props) {
+		if (!is_nameprop_id(PROP_ID(pv.proptag)))
+			continue;
+		auto it = std::find(src.begin(), src.end(), PROP_ID(pv.proptag));
+		if (it != src.end() && dst[it - src.begin()] == 0)
+			drop.push_back(pv.proptag);
+	}
+	for (auto tag : drop)
+		props.erase(tag);
 	for (unsigned int i = 0; i < props.count; ++i) {
 		auto oldtag = props.ppropval[i].proptag;
 		if (!is_nameprop_id(PROP_ID(oldtag)))
@@ -292,24 +316,29 @@ static void rx_npid_transform(TPROPVAL_ARRAY &props,
 		auto it = std::find(src.begin(), src.end(), PROP_ID(oldtag));
 		if (it == src.end())
 			continue;
-		props.ppropval[i].proptag = PROP_TAG(PROP_TYPE(oldtag), dst[it - src.begin()]);
+		auto newid = dst[it - src.begin()];
+		if (newid == 0)
+			continue; /* dropped above */
+		props.ppropval[i].proptag = PROP_TAG(PROP_TYPE(oldtag), newid);
 	}
+	return drop.size();
 }
 
-static void rx_npid_transform(MESSAGE_CONTENT &ctnt,
+static size_t rx_npid_transform(MESSAGE_CONTENT &ctnt,
     const std::vector<uint16_t> &src, const PROPID_ARRAY &dst)
 {
-	rx_npid_transform(ctnt.proplist, src, dst);
+	size_t dropped = rx_npid_transform(ctnt.proplist, src, dst);
 	if (ctnt.children.prcpts != nullptr)
 		for (auto &rcpt : *ctnt.children.prcpts)
-			rx_npid_transform(rcpt, src, dst);
+			dropped += rx_npid_transform(rcpt, src, dst);
 	if (ctnt.children.pattachments != nullptr) {
 		for (auto &at : *ctnt.children.pattachments) {
-			rx_npid_transform(at.proplist, src, dst);
+			dropped += rx_npid_transform(at.proplist, src, dst);
 			if (at.pembedded != nullptr)
-				rx_npid_transform(*at.pembedded, src, dst);
+				dropped += rx_npid_transform(*at.pembedded, src, dst);
 		}
 	}
+	return dropped;
 }
 
 static ec_error_t rx_npid_replace(rxparam &par, MESSAGE_CONTENT &ctnt,
@@ -343,7 +372,12 @@ static ec_error_t rx_npid_replace(rxparam &par, MESSAGE_CONTENT &ctnt,
 		mlog(LV_ERR, "ruleproc: np(dst) counts are fishy");
 		return ecError;
 	}
-	rx_npid_transform(ctnt, src_id_vec, dst_id_arr);
+	auto dropped = rx_npid_transform(ctnt, src_id_vec, dst_id_arr);
+	if (dropped > 0)
+		mlog(LV_WARN, "ruleproc: %zu named property value%s omitted from "
+			"the copy because %s would not name them (its "
+			"named-property table may be full)", dropped,
+			dropped == 1 ? " was" : "s were", newdir);
 	return ecSuccess;
 }
 


### PR DESCRIPTION
## Problem

Every mailbox keeps its own private numbered index of custom field names. "Invoice number" might be entry 40001 in one mailbox and entry 40007 in another. The numbers are local; only the names mean anything across mailboxes.

So when a rule copies a message into a different mailbox, the numbers on that message have to be translated: look up what each number means in the source mailbox, then ask the target mailbox for its own numbers for those same names, creating them if it does not have them yet.

The problem is what happens when the target mailbox's index is full. It stops adding names — and it reports this by handing back the number 0 for each name it did not add, while still reporting overall success. Nothing anywhere returns an error.

The code then writes 0 onto the message as if it were a real number. 0 is not a valid entry in anyone's index, so the message lands in the target mailbox carrying fields that point at nothing. And because the index is full, this does not happen to one field on one message — it happens to every custom field on every message copied there.

The check that was supposed to catch this compares how many numbers were asked for against how many came back. Those two are always equal, so the check can never fail. The bad news is inside the list, not in its length.
