### PR TITLE
ews: fix dangling PR_SENDER_NAME/PR_SENT_REPRESENTING_NAME pointer in toContent

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -4251,7 +4251,15 @@ void EWSContext::toContent(const std::string& dir, tCalendarItem& item, sShape& 
 		std::string dispName;
 		if (!mysql_adaptor_get_user_displayname(m_auth_info.username, dispName))
 			throw DispatchError(E3378);
-		auto displayName = deconst(dispName.c_str());
+		/*
+		 * shape.write() does not deep-copy string property values (the
+		 * backing memory must outlive this call, per its own doc
+		 * comment) - dispName is local to this function and would be
+		 * dangling by the time the shape is materialized by the
+		 * caller, corrupting PR_SENDER_NAME/PR_SENT_REPRESENTING_NAME
+		 * with whatever later reuses this stack slot.
+		 */
+		auto displayName = strcpy(alloc<char>(dispName.size() + 1), dispName.c_str());
 		shape.write(TAGGED_PROPVAL{PR_SENT_REPRESENTING_NAME, displayName});
 		shape.write(TAGGED_PROPVAL{PR_SENDER_NAME, displayName});
 		auto username = deconst(m_auth_info.username);


### PR DESCRIPTION
## Summary

`shape.write()` does not deep-copy string property values - per its own doc comment, the backing memory must outlive the call. `toContent()` (calendar item path) passed a pointer into a `std::string` (`dispName`) that is local to the function for `PR_SENT_REPRESENTING_NAME`/`PR_SENDER_NAME`:

```c++
std::string dispName;
mysql_adaptor_get_user_displayname(m_auth_info.username, dispName);
auto displayName = deconst(dispName.c_str());
shape.write(TAGGED_PROPVAL{PR_SENT_REPRESENTING_NAME, displayName});
shape.write(TAGGED_PROPVAL{PR_SENDER_NAME, displayName});
```

Once the function returns, `dispName` is destroyed and the pointer is left dangling by the time the shape is actually materialized by the caller - corrupting whichever of these two properties with whatever later reuses that stack slot.

## Fix

Allocate the display name from the arena instead, matching the pattern already used a few hundred lines below for `PR_LAST_MODIFIER_NAME`.

## Testing

Compiles clean; `libgromox_ews.la` links. Have not managed to reliably reproduce the corrupted-name symptom itself (stack-slot reuse is inherently non-deterministic), but the lifetime violation is unambiguous by inspection and matches the documented contract of `shape.write()`.
