### PR TITLE
ews: make the streaming subscription timeout configurable

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -4911,7 +4911,7 @@ tSubscriptionId EWSContext::subscribe(const tStreamingSubscriptionRequest& req) 
 	if (all && req.FolderIds)
 		throw EWSError::InvalidSubscriptionRequest(E3383);
 	return subscribe(req.FolderIds ? *req.FolderIds : std::vector<sFolderId>(),
-	       req.eventMask(), all, 5);
+	       req.eventMask(), all, m_plugin.streaming_subscription_timeout);
 }
 
 /**

--- a/exch/ews/ews.cpp
+++ b/exch/ews/ews.cpp
@@ -512,6 +512,7 @@ static constexpr cfg_directive ews_cfg_defaults[] = {
 	{"ews_request_logging", "0"},
 	{"ews_response_logging", "0"},
 	{"ews_schema_version", "V2017_07_11"},
+	{"ews_streaming_subscription_timeout", "1440"},
 	CFG_TABLE_END,
 };
 
@@ -557,6 +558,7 @@ void EWSPlugin::loadConfig()
 	max_sync_changes = cfg->get_ll("ews_max_sync_changes");
 	max_get_items = cfg->get_ll("ews_max_get_items");
 	max_pending_events = cfg->get_ll("ews_max_pending_events");
+	streaming_subscription_timeout = cfg->get_ll("ews_streaming_subscription_timeout");
 	ver.schema = cfg->get_value("ews_schema_version");
 
 	str = gxcfg->get_value("outgoing_smtp_url");

--- a/exch/ews/ews.hpp
+++ b/exch/ews/ews.hpp
@@ -166,6 +166,7 @@ class EWSPlugin {
 	uint32_t max_sync_changes = 512; ///< SyncFolderItems items per page; clamps client MaxChangesReturned, 0 = unlimited. Matches Exchange's 512 limit.
 	uint32_t max_get_items = 0; ///< Optional GetItem batch cap, 0 = unlimited (Exchange does not cap this; overflow -> ErrorServerBusy)
 	uint32_t max_pending_events = 4000; ///< Per-subscription undelivered streaming-event cap, 0 = unlimited. Backlog past this faults the subscription out so the client re-subscribes and resyncs, instead of pinning RSS.
+	uint32_t streaming_subscription_timeout = 1440; ///< Minutes a streaming subscription's server-side state survives without a GetStreamingEvents/GetEvents touch. Must comfortably exceed common client-side gaps (laptop sleep, travel, network roaming) or the subscription is evicted silently and the client is left polling a dead id forever. Bounded by ews_max_pending_events regardless of how long this is set to, so a generous value is low-risk.
 	std::chrono::milliseconds cache_interval{5'000}; ///< Interval for cache cleanup
 	std::chrono::milliseconds cache_attachment_instance_lifetime{30'000}; ///< Lifetime of attachment instances
 	std::chrono::milliseconds cache_embedded_instance_lifetime{30'000}; ///< Lifetime of embedded instances


### PR DESCRIPTION
## Summary

`EWSContext::subscribe()` for streaming subscriptions hardcoded the subscription manager's timeout to `5` (minutes) regardless of what's sane for real-world usage:

```c++
return subscribe(req.FolderIds ? *req.FolderIds : std::vector<sFolderId>(),
       req.eventMask(), all, 5);
```

This value backs the cache entry for the subscription (`tSubscriptionId::timeout`, minutes -> `ID.timeout * 60'000` ms in the cache TTL) - once it expires without a `GetStreamingEvents`/`GetEvents` touch, the subscription is evicted server-side.

5 minutes is short enough that ordinary client-side gaps (laptop sleep, travel, network roaming) can outlast it: the subscription disappears silently and the client is left polling a dead id with no way to tell, short of resubscribing from scratch. Observed this contribute to real Outlook desync in production.

## Fix

Added `ews_streaming_subscription_timeout` (default `1440` = 24h) so this is configurable instead of hardcoded. It's bounded in practice by `ews_max_pending_events` regardless of how long it's set to, so a generous default is low-risk.

## Testing

Compiles clean; `libgromox_ews.la` links. Running with the new default in this deployment.
