### PR TITLE
exmdb, emsmdb: make opening a large folder faster

### DIFF
--- a/exch/exmdb/common_util.cpp
+++ b/exch/exmdb/common_util.cpp
@@ -418,6 +418,14 @@ bool prepared_statements::begin(sqlite3 *psqlite)
 	           "messages WHERE message_id=?");
 	if (msg_read == nullptr)
 		return false;
+	msg_atx = gx_sql_prep(psqlite, "SELECT 1 FROM attachments "
+	          "WHERE message_id=? LIMIT 1");
+	if (msg_atx == nullptr)
+		return false;
+	msg_fai = gx_sql_prep(psqlite, "SELECT is_associated FROM "
+	          "messages WHERE message_id=?");
+	if (msg_fai == nullptr)
+		return false;
 	return true;
 }
 
@@ -1127,15 +1135,24 @@ static BINARY *cu_mid_to_entryid(sqlite3 *psqlite, uint64_t message_id)
 	return pbin;
 }
 
-bool cu_msg_is_fai(sqlite3 *psqlite, uint64_t message_id)
+bool cu_msg_is_fai(const db_conn &db, uint64_t message_id)
 {
-	char sql_string[128];
-	
-	snprintf(sql_string, std::size(sql_string), "SELECT is_associated FROM "
-	          "messages WHERE message_id=%llu", LLU{message_id});
-	auto pstmt = gx_sql_prep(psqlite, sql_string);
-	return pstmt != nullptr && pstmt.step() == SQLITE_ROW &&
-	       pstmt.col_int64(0) != 0;
+	xstmt own_stmt;
+	sqlite3_stmt *pstmt = nullptr;
+	if (g_exmdb_enable_optim_stm && db.m_prepstm != nullptr)
+		pstmt = db.m_prepstm->msg_fai;
+	if (pstmt != nullptr) {
+		sqlite3_reset(pstmt);
+	} else {
+		own_stmt = gx_sql_prep(db.psqlite, "SELECT is_associated FROM "
+		           "messages WHERE message_id=?");
+		if (own_stmt == nullptr)
+			return false;
+		pstmt = own_stmt;
+	}
+	sqlite3_bind_int64(pstmt, 1, message_id);
+	return gx_sql_step(pstmt) == SQLITE_ROW &&
+	       sqlite3_column_int64(pstmt, 0) != 0;
 }
 
 static bool cu_msg_has_namedprops(sqlite3 *psqlite, uint64_t message_id)
@@ -1152,14 +1169,23 @@ static bool cu_msg_has_namedprops(sqlite3 *psqlite, uint64_t message_id)
 	return pstmt.step() == SQLITE_ROW;
 }
 
-static bool cu_msg_has_attachments(sqlite3 *psqlite, uint64_t message_id)
+static bool cu_msg_has_attachments(const db_conn &db, uint64_t message_id)
 {
-	char sql_string[128];
-	
-	snprintf(sql_string, std::size(sql_string), "SELECT 1 FROM "
-	          "attachments WHERE message_id=%llu LIMIT 1", LLU{message_id});
-	auto pstmt = gx_sql_prep(psqlite, sql_string);
-	return pstmt != nullptr && pstmt.step() == SQLITE_ROW;
+	xstmt own_stmt;
+	sqlite3_stmt *pstmt = nullptr;
+	if (g_exmdb_enable_optim_stm && db.m_prepstm != nullptr)
+		pstmt = db.m_prepstm->msg_atx;
+	if (pstmt != nullptr) {
+		sqlite3_reset(pstmt);
+	} else {
+		own_stmt = gx_sql_prep(db.psqlite, "SELECT 1 FROM attachments "
+		           "WHERE message_id=? LIMIT 1");
+		if (own_stmt == nullptr)
+			return false;
+		pstmt = own_stmt;
+	}
+	sqlite3_bind_int64(pstmt, 1, message_id);
+	return gx_sql_step(pstmt) == SQLITE_ROW;
 }
 
 static bool cu_msg_is_read(const db_conn &db, uint64_t message_id)
@@ -1239,9 +1265,9 @@ bool cu_get_msg_flags(const db_conn &db, uint64_t message_id, bool b_native,
 	if (!b_native) {
 		if (cu_msg_is_read(db, message_id))
 			message_flags |= MSGFLAG_READ;
-		if (cu_msg_has_attachments(psqlite, message_id))
+		if (cu_msg_has_attachments(db, message_id))
 			message_flags |= MSGFLAG_HASATTACH;
-		if (cu_msg_is_fai(psqlite, message_id))
+		if (cu_msg_is_fai(db, message_id))
 			message_flags |= MSGFLAG_ASSOCIATED;
 		sqlite3_reset(pstmt);
 		sqlite3_bind_int64(pstmt, 1, message_id);
@@ -1855,7 +1881,7 @@ static GP_RESULT gp_msgprop(proptag_t tag, TAGGED_PROPVAL &pv,
 		pv.pvalue = v;
 		if (pv.pvalue == nullptr)
 			return GP_ERR;
-		*v = cu_msg_is_fai(db, id);
+		*v = cu_msg_is_fai(db_conn, id);
 		return GP_ADV;
 	}
 	case PidTagChangeNumber: {
@@ -1888,7 +1914,7 @@ static GP_RESULT gp_msgprop(proptag_t tag, TAGGED_PROPVAL &pv,
 		pv.pvalue = v;
 		if (pv.pvalue == nullptr)
 			return GP_ERR;
-		*v = cu_msg_has_attachments(db, id);
+		*v = cu_msg_has_attachments(db_conn, id);
 		return GP_ADV;
 	}
 	case PidTagMid: {

--- a/exch/exmdb/common_util.cpp
+++ b/exch/exmdb/common_util.cpp
@@ -1240,9 +1240,19 @@ static uint64_t common_util_get_message_changenum(
 	return rop_util_make_eid_ex(1, change_num);
 }
 
+/**
+ * @want:	which bits of the result the caller will look at. Bits outside it
+ * 		are left cleared and the lookups that would only have served
+ * 		them are skipped. Callers wanting the whole value omit it.
+ *
+ * Each of the recomputed bits costs one lookup.
+ */
 bool cu_get_msg_flags(const db_conn &db, uint64_t message_id, bool b_native,
-	uint32_t **ppmessage_flags)
+	uint32_t **ppmessage_flags, uint32_t want)
 {
+	static constexpr uint32_t recomputed =
+		MSGFLAG_READ | MSGFLAG_HASATTACH | MSGFLAG_FROMME |
+		MSGFLAG_ASSOCIATED | MSGFLAG_RN_PENDING | MSGFLAG_NRN_PENDING;
 	auto pstmt = cu_get_optimize_stmt(db, MAPI_MESSAGE, true);
 	xstmt own_stmt;
 	auto &psqlite = db.psqlite;
@@ -1253,41 +1263,50 @@ bool cu_get_msg_flags(const db_conn &db, uint64_t message_id, bool b_native,
 		           "FROM message_properties WHERE message_id=?"
 		           " AND proptag=?");
 		if (own_stmt == nullptr)
-			return FALSE;
+			return false;
 		pstmt = own_stmt;
 	}
-	sqlite3_bind_int64(pstmt, 1, message_id);
-	sqlite3_bind_int64(pstmt, 2, PR_MESSAGE_FLAGS);
-	uint32_t message_flags = gx_sql_step(pstmt) == SQLITE_ROW ?
-	                         sqlite3_column_int64(pstmt, 0) : 0;
-	message_flags &= ~(MSGFLAG_READ | MSGFLAG_HASATTACH | MSGFLAG_FROMME |
-	                 MSGFLAG_ASSOCIATED | MSGFLAG_RN_PENDING | MSGFLAG_NRN_PENDING);
+	uint32_t message_flags = 0;
+	if (b_native || (want & ~recomputed) != 0) {
+		/* the stored value supplies only the bits not recomputed below */
+		sqlite3_bind_int64(pstmt, 1, message_id);
+		sqlite3_bind_int64(pstmt, 2, PR_MESSAGE_FLAGS);
+		message_flags = gx_sql_step(pstmt) == SQLITE_ROW ?
+		                sqlite3_column_int64(pstmt, 0) : 0;
+		message_flags &= ~recomputed;
+	}
 	if (!b_native) {
-		if (cu_msg_is_read(db, message_id))
+		if ((want & MSGFLAG_READ) && cu_msg_is_read(db, message_id))
 			message_flags |= MSGFLAG_READ;
-		if (cu_msg_has_attachments(db, message_id))
+		if ((want & MSGFLAG_HASATTACH) && cu_msg_has_attachments(db, message_id))
 			message_flags |= MSGFLAG_HASATTACH;
-		if (cu_msg_is_fai(db, message_id))
+		if ((want & MSGFLAG_ASSOCIATED) && cu_msg_is_fai(db, message_id))
 			message_flags |= MSGFLAG_ASSOCIATED;
-		sqlite3_reset(pstmt);
-		sqlite3_bind_int64(pstmt, 1, message_id);
-		sqlite3_bind_int64(pstmt, 2, PR_READ_RECEIPT_REQUESTED);
-		if (gx_sql_step(pstmt) == SQLITE_ROW)
-			if (sqlite3_column_int64(pstmt, 0) != 0)
+		if (want & MSGFLAG_RN_PENDING) {
+			sqlite3_reset(pstmt);
+			sqlite3_bind_int64(pstmt, 1, message_id);
+			sqlite3_bind_int64(pstmt, 2, PR_READ_RECEIPT_REQUESTED);
+			if (gx_sql_step(pstmt) == SQLITE_ROW &&
+			    sqlite3_column_int64(pstmt, 0) != 0)
 				message_flags |= MSGFLAG_RN_PENDING;
-		sqlite3_reset(pstmt);
-		sqlite3_bind_int64(pstmt, 1, message_id);
-		sqlite3_bind_int64(pstmt, 2, PR_NON_RECEIPT_NOTIFICATION_REQUESTED);
-		if (gx_sql_step(pstmt) == SQLITE_ROW)
-			if (sqlite3_column_int64(pstmt, 0) != 0)
+		}
+		if (want & MSGFLAG_NRN_PENDING) {
+			sqlite3_reset(pstmt);
+			sqlite3_bind_int64(pstmt, 1, message_id);
+			sqlite3_bind_int64(pstmt, 2, PR_NON_RECEIPT_NOTIFICATION_REQUESTED);
+			if (gx_sql_step(pstmt) == SQLITE_ROW &&
+			    sqlite3_column_int64(pstmt, 0) != 0)
 				message_flags |= MSGFLAG_NRN_PENDING;
+		}
+		if (exmdb_pf_read_states == 0 && !exmdb_server::is_private())
+			message_flags |= MSGFLAG_READ;
 	}
 	own_stmt.finalize();
 	*ppmessage_flags = cu_alloc<uint32_t>();
 	if (*ppmessage_flags == nullptr)
-		return FALSE;
+		return false;
 	**ppmessage_flags = message_flags;
-	return TRUE;
+	return true;
 }
 
 static char *cu_get_msg_parent_display(const db_conn &psqlite, uint64_t message_id)
@@ -1929,11 +1948,7 @@ static GP_RESULT gp_msgprop(proptag_t tag, TAGGED_PROPVAL &pv,
 		if (!cu_get_msg_flags(db_conn, id, false,
 		    reinterpret_cast<uint32_t **>(&pv.pvalue)))
 			return GP_ERR;
-		if (pv.pvalue == nullptr)
-			return GP_SKIP;
-		if (exmdb_pf_read_states == 0 && !exmdb_server::is_private())
-			*static_cast<uint32_t *>(pv.pvalue) |= MSGFLAG_READ;
-		return GP_ADV;
+		return pv.pvalue != nullptr ? GP_ADV : GP_SKIP;
 	case PR_SUBJECT:
 	case PR_SUBJECT_A:
 		if (!common_util_get_message_subject(db_conn, cpid, id, tag, &pv.pvalue))
@@ -4523,6 +4538,16 @@ bool cu_eval_msg_restriction(const db_conn &psqlite,
 		auto rbm = pres->bm;
 		if (!rbm->comparable())
 			return FALSE;
+		if (rbm->proptag == PR_MESSAGE_FLAGS) {
+			/*
+			 * The flag is computed from one lookup per bit, and only
+			 * the bits in the mask can change the outcome.
+			 */
+			uint32_t *flags = nullptr;
+			if (!cu_get_msg_flags(psqlite, message_id, false, &flags, rbm->mask))
+				return FALSE;
+			return flags != nullptr && rbm->eval(flags);
+		}
 		if (!cu_get_property(MAPI_MESSAGE,
 		    message_id, cpid, psqlite, rbm->proptag, &pvalue))
 			return FALSE;

--- a/exch/exmdb/db_engine.hpp
+++ b/exch/exmdb/db_engine.hpp
@@ -109,7 +109,8 @@ struct instance_node {
 
 struct prepared_statements {
 	bool begin(sqlite3 *);
-	gromox::xstmt msg_norm, msg_str, rcpt_norm, rcpt_str, msg_read;
+	gromox::xstmt msg_norm, msg_str, rcpt_norm, rcpt_str, msg_read,
+		msg_atx, msg_fai;
 };
 
 struct db_close;

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -927,12 +927,77 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 	auto cl_optim = HX::make_scope_exit([&]() { db.end_optim(); });
 
 	/*
+	 * An unsorted table without a restriction takes every row the scan
+	 * yields, in scan order, so rows can go in several at a time. row_id is
+	 * assigned consecutively by AUTOINCREMENT, which prev_id and idx are
+	 * derived from, so both are known before the insert.
+	 */
+	bool rows_done = psorts == nullptr && conv_id == nullptr &&
+	                 prestriction == nullptr;
+	if (rows_done) {
+		auto stm = db.eph_prep(fmt::format("SELECT IFNULL(MAX(row_id), 0) FROM t{}", table_id));
+		if (stm == nullptr || stm.step() != SQLITE_ROW)
+			return false;
+		uint64_t next_row = stm.col_uint64(0) + 1;
+		stm.finalize();
+
+		static constexpr unsigned int batch = 128;
+		auto row_tpl = fmt::format("(?, ?, {}, 0, 0, ?)", CONTENT_ROW_MESSAGE);
+		auto head = fmt::format("INSERT INTO t{} (inst_id, prev_id, "
+		            "row_type, depth, inst_num, idx) VALUES ", table_id);
+		std::string batch_sql = head;
+		for (unsigned int i = 0; i < batch; ++i)
+			batch_sql += (i == 0 ? "" : ", ") + row_tpl;
+		auto bstm = db.eph_prep(batch_sql);
+		if (bstm == nullptr)
+			return false;
+
+		std::vector<uint64_t> mids;
+		mids.reserve(batch);
+		auto flush = [&]() {
+			sqlite3_stmt *st = bstm;
+			xstmt tail;
+			if (mids.size() != batch) {
+				std::string s = head;
+				for (size_t i = 0; i < mids.size(); ++i)
+					s += (i == 0 ? "" : ", ") + row_tpl;
+				tail = db.eph_prep(s);
+				if (tail == nullptr)
+					return false;
+				st = tail;
+			} else {
+				sqlite3_reset(st);
+			}
+			for (size_t i = 0; i < mids.size(); ++i) {
+				auto row = next_row + i;
+				sqlite3_bind_int64(st, i * 3 + 1, mids[i]);
+				sqlite3_bind_int64(st, i * 3 + 2, row - 1);
+				sqlite3_bind_int64(st, i * 3 + 3, row);
+			}
+			if (gx_sql_step(st) != SQLITE_DONE)
+				return false;
+			next_row += mids.size();
+			mids.clear();
+			return true;
+		};
+		while (pstmt.step() == SQLITE_ROW) {
+			mids.push_back(pstmt.col_uint64(0));
+			if (mids.size() == batch && !flush())
+				return false;
+		}
+		if (!mids.empty() && !flush())
+			return false;
+		pstmt.finalize();
+		pstmt1.finalize();
+	}
+
+	/*
 	 * [Block 3] Loop for reading the folder content. The first pass either
 	 * fills the MAPI content table, or, in case a sort criteria is
 	 * defined, stbl.
 	 */
 	uint64_t last_row_id = 0;
-	while (pstmt.step() == SQLITE_ROW) {
+	while (!rows_done && pstmt.step() == SQLITE_ROW) {
 		uint64_t mid_val = pstmt.col_uint64(0);
 		if (conv_id != nullptr) {
 			uint64_t parent_fid = 0;

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -1001,7 +1001,7 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 		uint64_t mid_val = pstmt.col_uint64(0);
 		if (conv_id != nullptr) {
 			uint64_t parent_fid = 0;
-			if (cu_msg_is_fai(db.psqlite, mid_val))
+			if (cu_msg_is_fai(db, mid_val))
 				continue;
 			if (!common_util_get_message_parent_folder(db.psqlite,
 			    mid_val, &parent_fid))

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -372,16 +372,14 @@ template<typename F> static sqlite3_stmt *tlc_prep(tlc_stmt_cache &cache,
 static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 	const SORTORDER_SET *psorts, int depth, uint64_t parent_id,
     std::vector<condition_node> &cond_list, sqlite3_stmt *pstmt_insert,
-	uint32_t *pheader_id, sqlite3_stmt *pstmt_update,
-    uint32_t *punread_count, tlc_stmt_cache &stmt_cache) try
+	uint32_t *pheader_id, tlc_stmt_cache &stmt_cache) try
 {
 	void *pvalue;
 	int bind_index;
 	int multi_index;
 	bool b_extremum;
 	uint64_t header_id;
-	uint32_t unread_count;
-	
+
 	int64_t prev_id = -parent_id;
 	if (depth == psorts->ccategories) {
 		proptag_t tmp_proptag;
@@ -452,7 +450,6 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 			if (psorts->ccategories <= 0) {
 				sqlite3_bind_null(pstmt_insert, 9);
 			} else if (0 == sqlite3_column_int64(pstmt, 1)) {
-				(*punread_count)++;
 				/* unread(0) in extremum for message row */
 				sqlite3_bind_int64(pstmt_insert, 9, 0);
 			} else {
@@ -481,6 +478,8 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 				sqlite3_bind_null(pstmt_insert, 8);
 			}
 			sqlite3_bind_int64(pstmt_insert, 10, prev_id);
+			/* unread only applies to header rows */
+			sqlite3_bind_null(pstmt_insert, 11);
 			if (gx_sql_step(pstmt_insert) != SQLITE_DONE)
 				return FALSE;
 			prev_id = sqlite3_last_insert_rowid(db.m_sqlite_eph);
@@ -499,12 +498,12 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 			auto tmp_proptag1 = PROP_TAG(psorts->psort[depth+1].type, psorts->psort[depth+1].propid);
 			auto agg = TABLE_SORT_MAXIMUM_CATEGORY ==
 			           psorts->psort[depth+1].table_sort ? "MAX" : "MIN";
-			qstr = fmt::format("SELECT v{:x}, COUNT(*), {}(v{:x}) AS max_field "
-			       "FROM stbl {} GROUP BY v{:x} ORDER BY max_field",
+			qstr = fmt::format("SELECT v{:x}, COUNT(*), {}(v{:x}) AS max_field, "
+			       "SUM(read_state=0) FROM stbl {} GROUP BY v{:x} ORDER BY max_field",
 			       tmp_proptag, agg, tmp_proptag1, where, tmp_proptag);
 		} else {
-			qstr = fmt::format("SELECT v{:x}, COUNT(*) FROM stbl {} "
-			       "GROUP BY v{:x} ORDER BY v{:x}",
+			qstr = fmt::format("SELECT v{:x}, COUNT(*), NULL, SUM(read_state=0) "
+			       "FROM stbl {} GROUP BY v{:x} ORDER BY v{:x}",
 			       tmp_proptag, where, tmp_proptag, tmp_proptag);
 		}
 		qstr += psorts->psort[depth].table_sort == TABLE_SORT_ASCEND ?
@@ -556,23 +555,22 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 		else if (!common_util_bind_sqlite_statement(pstmt_insert, 8, type, pvalue))
 			return FALSE;
 		sqlite3_bind_int64(pstmt_insert, 10, prev_id);
+		/*
+		 * Unread is the number of unread messages anywhere below this
+		 * header, which is what SUM over the group yields: the group holds
+		 * every stbl row this category covers, at any depth.
+		 */
+		sqlite3_bind_int64(pstmt_insert, 11, sqlite3_column_int64(pstmt, 3));
 		if (gx_sql_step(pstmt_insert) != SQLITE_DONE)
 			return FALSE;
 		prev_id = sqlite3_last_insert_rowid(db.m_sqlite_eph);
 		sqlite3_reset(pstmt_insert);
 		tmp_cnode.proptag = tmp_proptag;
-		unread_count = 0;
 		tmp_cnode.pvalue = pvalue;
 		if (!table_load_content(db, psqlite, psorts,
 		    depth + 1, prev_id, cond_list, pstmt_insert,
-		    pheader_id, pstmt_update, &unread_count, stmt_cache))
+		    pheader_id, stmt_cache))
 			return FALSE;
-		sqlite3_bind_int64(pstmt_update, 1, unread_count);
-		sqlite3_bind_int64(pstmt_update, 2, prev_id);
-		if (gx_sql_step(pstmt_update) != SQLITE_DONE)
-			return FALSE;
-		sqlite3_reset(pstmt_update);
-		*punread_count += unread_count;
 	}
 	cond_list.pop_back();
 	return TRUE;
@@ -1038,25 +1036,19 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 	if (NULL != psorts) {
 		sql_string = fmt::format("INSERT INTO t{} "
 		             "(inst_id, row_type, row_stat, parent_id, depth, "
-		             "count, inst_num, value, extremum, prev_id) VALUES"
-		             " (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", table_id);
+		             "count, inst_num, value, extremum, prev_id, unread) VALUES"
+		             " (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", table_id);
 		pstmt = db.eph_prep(sql_string);
 		if (pstmt == nullptr)
 			return false;
-		sql_string = fmt::format("UPDATE t{} SET unread=? WHERE row_id=?", table_id);
-		pstmt1 = db.eph_prep(sql_string);
-		if (pstmt1 == nullptr)
-			return false;
 
 		std::vector<condition_node> cond_list;
-		uint32_t unread_count = 0;
 		tlc_stmt_cache stmt_cache;
 		if (!table_load_content(db, psqlite, psorts, 0, 0, cond_list,
-		    pstmt, &ptnode->header_id, pstmt1, &unread_count, stmt_cache))
+		    pstmt, &ptnode->header_id, stmt_cache))
 			return false;
 		stmt_cache.clear();
 		pstmt.finalize();
-		pstmt1.finalize();
 		/*
 		 * These serve later table operations; nothing above reads t{}
 		 * through them.

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -10,6 +10,8 @@
 #include <fcntl.h>
 #include <iconv.h>
 #include <list>
+#include <map>
+#include <string>
 #include <unistd.h>
 #include <utility>
 #include <vector>
@@ -310,6 +312,9 @@ BOOL exmdb_server::sum_content(const char *dir, uint64_t folder_id,
 	return TRUE;
 }
 
+/* Sort criteria a content table may carry; psort[] is indexed by category depth. */
+static constexpr size_t gct_max_sorts = 16;
+
 static std::string table_cond_to_where(const std::vector<condition_node> &list)
 {
 	std::string w;
@@ -326,22 +331,58 @@ static std::string table_cond_to_where(const std::vector<condition_node> &list)
 	return w;
 }
 
+/**
+ * The per-category queries only vary with the recursion depth, with whether
+ * this is the message level, and with which of the enclosing category values
+ * are NULL (those are inlined into the WHERE clause rather than bound). A
+ * table with many categories therefore reuses the same handful of statements,
+ * and the query text need only be built when one is missing.
+ */
+using tlc_stmt_cache = std::map<uint64_t, xstmt>;
+
+static uint64_t tlc_stmt_key(const std::vector<condition_node> &cond_list,
+    int depth, bool leaf)
+{
+	static_assert(gct_max_sorts <= 64,
+		"nullmask below is a uint64_t, one bit per category depth");
+	uint64_t nullmask = 0;
+	size_t i = 0;
+	for (const auto &cnode : cond_list) {
+		if (cnode.pvalue == nullptr)
+			nullmask |= static_cast<uint64_t>(1) << i;
+		++i;
+	}
+	return nullmask << 16 | static_cast<uint64_t>(depth) << 1 | !!leaf;
+}
+
+template<typename F> static sqlite3_stmt *tlc_prep(tlc_stmt_cache &cache,
+    sqlite3 *psqlite, uint64_t key, F &&make_query)
+{
+	auto iter = cache.find(key);
+	if (iter != cache.end()) {
+		sqlite3_reset(iter->second);
+		return iter->second;
+	}
+	auto stmt = gx_sql_prep(psqlite, make_query());
+	if (stmt == nullptr)
+		return nullptr;
+	return cache.emplace(key, std::move(stmt)).first->second;
+}
+
 static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 	const SORTORDER_SET *psorts, int depth, uint64_t parent_id,
     std::vector<condition_node> &cond_list, sqlite3_stmt *pstmt_insert,
 	uint32_t *pheader_id, sqlite3_stmt *pstmt_update,
-    uint32_t *punread_count) try
+    uint32_t *punread_count, tlc_stmt_cache &stmt_cache) try
 {
 	void *pvalue;
-	BOOL b_orderby;
 	int bind_index;
 	int multi_index;
-	BOOL b_extremum;
+	bool b_extremum;
 	uint64_t header_id;
 	uint32_t unread_count;
 	
 	int64_t prev_id = -parent_id;
-	auto where = table_cond_to_where(cond_list);
 	if (depth == psorts->ccategories) {
 		proptag_t tmp_proptag;
 		multi_index = -1;
@@ -352,40 +393,45 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 				break;
 			}
 		}
-		std::string qstr;
-		if (multi_index != -1)
-			qstr = fmt::format("SELECT message_id, read_state, "
-			       "inst_num, v{:x} FROM stbl {}", tmp_proptag, where);
-		else
-			qstr = fmt::format("SELECT message_id, read_state, "
-			       "inst_num FROM stbl {}", where);
-		b_orderby = FALSE;
-		for (unsigned int i = psorts->ccategories; i < psorts->count; ++i) {
-			tmp_proptag = PROP_TAG(psorts->psort[i].type, psorts->psort[i].propid);
-			if (tablesort_is_minmax(psorts->psort[i].table_sort))
-				continue;
-			auto ord = psorts->psort[i].table_sort == TABLE_SORT_ASCEND ?
-			           " ASC" : " DESC";
-			if (!b_orderby) {
-				qstr += fmt::format(" ORDER BY v{:x} {}", tmp_proptag, ord);
-				b_orderby = TRUE;
-			} else {
-				qstr += fmt::format(", v{:x} {}", tmp_proptag, ord);
+		auto make_query = [&]() {
+			auto where = table_cond_to_where(cond_list);
+			std::string qstr;
+			if (multi_index != -1)
+				qstr = fmt::format("SELECT message_id, read_state, "
+				       "inst_num, v{:x} FROM stbl {}", tmp_proptag, where);
+			else
+				qstr = fmt::format("SELECT message_id, read_state, "
+				       "inst_num FROM stbl {}", where);
+			bool b_ord = false;
+			for (unsigned int i = psorts->ccategories; i < psorts->count; ++i) {
+				auto tag = PROP_TAG(psorts->psort[i].type, psorts->psort[i].propid);
+				if (tablesort_is_minmax(psorts->psort[i].table_sort))
+					continue;
+				auto ord = psorts->psort[i].table_sort == TABLE_SORT_ASCEND ?
+				           " ASC" : " DESC";
+				if (!b_ord) {
+					qstr += fmt::format(" ORDER BY v{:x} {}", tag, ord);
+					b_ord = true;
+				} else {
+					qstr += fmt::format(", v{:x} {}", tag, ord);
+				}
 			}
-		}
-		/*
-		 * For an uncategorized table, break ties on message_id (in the
-		 * primary sort direction) so a reload reproduces the order
-		 * that the live-insert notification path builds; otherwise
-		 * same-key rows can appear reordered/duplicated in online-mode
-		 * clients.
-		 */
-		if (b_orderby && psorts->ccategories == 0) {
-			auto ord = psorts->psort[0].table_sort == TABLE_SORT_ASCEND ?
-			           " ASC" : " DESC";
-			qstr += fmt::format(", message_id {}", ord);
-		}
-		auto pstmt = gx_sql_prep(psqlite, qstr);
+			/*
+			 * For an uncategorized table, break ties on message_id (in the
+			 * primary sort direction) so a reload reproduces the order
+			 * that the live-insert notification path builds; otherwise
+			 * same-key rows can appear reordered/duplicated in online-mode
+			 * clients.
+			 */
+			if (b_ord && psorts->ccategories == 0) {
+				auto ord = psorts->psort[0].table_sort == TABLE_SORT_ASCEND ?
+				           " ASC" : " DESC";
+				qstr += fmt::format(", message_id {}", ord);
+			}
+			return qstr;
+		};
+		auto pstmt = tlc_prep(stmt_cache, psqlite,
+		             tlc_stmt_key(cond_list, depth, true), make_query);
 		if (pstmt == nullptr)
 			return FALSE;
 		bind_index = 1;
@@ -402,7 +448,7 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 			bind_index++;
 			++i;
 		}
-		while (pstmt.step() == SQLITE_ROW) {
+		while (gx_sql_step(pstmt) == SQLITE_ROW) {
 			if (psorts->ccategories <= 0) {
 				sqlite3_bind_null(pstmt_insert, 9);
 			} else if (0 == sqlite3_column_int64(pstmt, 1)) {
@@ -442,31 +488,31 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 		}
 		return TRUE;
 	}
-	std::string qstr;
 	auto tmp_proptag = PROP_TAG(psorts->psort[depth].type, psorts->psort[depth].propid);
-	if (depth == psorts->ccategories - 1 &&
-	    psorts->count > psorts->ccategories &&
-	    tablesort_is_minmax(psorts->psort[depth+1].table_sort)) {
-		auto tmp_proptag1 = PROP_TAG(psorts->psort[depth+1].type, psorts->psort[depth+1].propid);
-		if (TABLE_SORT_MAXIMUM_CATEGORY ==
-			psorts->psort[depth + 1].table_sort) {
-			qstr = fmt::format("SELECT v{:x}, COUNT(*), MAX(v{:x}) AS max_field "
+	b_extremum = depth == psorts->ccategories - 1 &&
+	             psorts->count > psorts->ccategories &&
+	             tablesort_is_minmax(psorts->psort[depth+1].table_sort);
+	auto make_query = [&]() {
+		auto where = table_cond_to_where(cond_list);
+		std::string qstr;
+		if (b_extremum) {
+			auto tmp_proptag1 = PROP_TAG(psorts->psort[depth+1].type, psorts->psort[depth+1].propid);
+			auto agg = TABLE_SORT_MAXIMUM_CATEGORY ==
+			           psorts->psort[depth+1].table_sort ? "MAX" : "MIN";
+			qstr = fmt::format("SELECT v{:x}, COUNT(*), {}(v{:x}) AS max_field "
 			       "FROM stbl {} GROUP BY v{:x} ORDER BY max_field",
-			       tmp_proptag, tmp_proptag1, where, tmp_proptag);
+			       tmp_proptag, agg, tmp_proptag1, where, tmp_proptag);
 		} else {
-			qstr = fmt::format("SELECT v{:x}, COUNT(*), MIN(v{:x}) AS max_field "
-			       "FROM stbl {} GROUP BY v{:x} ORDER BY max_field",
-			       tmp_proptag, tmp_proptag1, where, tmp_proptag);
+			qstr = fmt::format("SELECT v{:x}, COUNT(*) FROM stbl {} "
+			       "GROUP BY v{:x} ORDER BY v{:x}",
+			       tmp_proptag, where, tmp_proptag, tmp_proptag);
 		}
-	} else {
-		b_extremum = FALSE;
-		qstr = fmt::format("SELECT v{:x}, COUNT(*) FROM stbl {} "
-		       "GROUP BY v{:x} ORDER BY v{:x}",
-		       tmp_proptag, where, tmp_proptag, tmp_proptag);
-	}
-	qstr += psorts->psort[depth].table_sort == TABLE_SORT_ASCEND ?
-	        " ASC" : " DESC";
-	auto pstmt = gx_sql_prep(psqlite, qstr);
+		qstr += psorts->psort[depth].table_sort == TABLE_SORT_ASCEND ?
+		        " ASC" : " DESC";
+		return qstr;
+	};
+	auto pstmt = tlc_prep(stmt_cache, psqlite,
+	             tlc_stmt_key(cond_list, depth, false), make_query);
 	if (pstmt == nullptr)
 		return FALSE;
 	bind_index = 1;
@@ -484,7 +530,7 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 		++i;
 	}
 	auto &tmp_cnode = cond_list.emplace_back();
-	while (pstmt.step() == SQLITE_ROW) {
+	while (gx_sql_step(pstmt) == SQLITE_ROW) {
 		(*pheader_id) ++;
 		header_id = *pheader_id | 0x100000000000000ULL;
 		sqlite3_bind_int64(pstmt_insert, 1, header_id);
@@ -519,7 +565,7 @@ static bool table_load_content(db_conn &db, sqlite3 *psqlite,
 		tmp_cnode.pvalue = pvalue;
 		if (!table_load_content(db, psqlite, psorts,
 		    depth + 1, prev_id, cond_list, pstmt_insert,
-		    pheader_id, pstmt_update, &unread_count))
+		    pheader_id, pstmt_update, &unread_count, stmt_cache))
 			return FALSE;
 		sqlite3_bind_int64(pstmt_update, 1, unread_count);
 		sqlite3_bind_int64(pstmt_update, 2, prev_id);
@@ -671,12 +717,15 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 	unsigned int col_inum = 0; /* stbl column number for inst_num */
 	size_t tag_count = 0;
 	void *pvalue;
-	proptag_t tmp_proptags[16];
+	proptag_t tmp_proptags[gct_max_sorts];
 
 	auto conv_id = (table_flags & TABLE_FLAG_CONVERSATIONMEMBERS) ?
 	               get_conv_id(prestriction) : nullptr;
 	if (psorts != nullptr && psorts->count > std::size(tmp_proptags))
-		return FALSE;	
+		return FALSE;
+	if (psorts != nullptr && psorts->ccategories > psorts->count)
+		/* psort[] holds count entries and is indexed by category depth */
+		return false;
 	bool b_search = false;
 	if (!exmdb_server::is_private()) {
 		exmdb_server::set_public_username(username);
@@ -1021,9 +1070,11 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 
 		std::vector<condition_node> cond_list;
 		uint32_t unread_count = 0;
+		tlc_stmt_cache stmt_cache;
 		if (!table_load_content(db, psqlite, psorts, 0, 0, cond_list,
-		    pstmt, &ptnode->header_id, pstmt1, &unread_count))
+		    pstmt, &ptnode->header_id, pstmt1, &unread_count, stmt_cache))
 			return false;
+		stmt_cache.clear();
 		pstmt.finalize();
 		pstmt1.finalize();
 		if (psort_transact.commit() != SQLITE_OK)

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -749,8 +749,8 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 		return false;
 	auto sql_string = fmt::format("CREATE TABLE t{} "
 		"(row_id INTEGER PRIMARY KEY AUTOINCREMENT, "
-		"idx INTEGER UNIQUE DEFAULT NULL, "
-		"prev_id INTEGER UNIQUE DEFAULT NULL, "
+		"idx INTEGER DEFAULT NULL, "
+		"prev_id INTEGER DEFAULT NULL, "
 		"inst_id INTEGER NOT NULL, "
 		"row_type INTEGER NOT NULL, "
 		"row_stat INTEGER DEFAULT NULL, "	/* expanded(1) or collapsed(0) */
@@ -764,20 +764,6 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 		table_id);
 	if (db.eph_exec(sql_string) != SQLITE_OK)
 		return FALSE;
-	if (NULL != psorts && psorts->ccategories > 0) {
-		sql_string = fmt::format("CREATE UNIQUE INDEX t{}_1 ON "
-		             "t{} (inst_id, inst_num)", table_id, table_id);
-		if (db.eph_exec(sql_string) != SQLITE_OK)
-			return FALSE;
-		sql_string = fmt::format("CREATE INDEX t{}_2 ON"
-		             " t{} (parent_id)", table_id, table_id);
-		if (db.eph_exec(sql_string) != SQLITE_OK)
-			return FALSE;
-		sql_string = fmt::format("CREATE INDEX t{}_3 ON t{}"
-		             " (parent_id, value)", table_id, table_id);
-		if (db.eph_exec(sql_string) != SQLITE_OK)
-			return FALSE;
-	}
 
 	std::list<table_node> holder;
 	auto ptnode = &holder.emplace_back();
@@ -908,12 +894,6 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 			if (gx_sql_exec(psqlite, sql_string) != SQLITE_OK)
 				return false;
 		}
-		if (ptnode->instance_tag == 0)
-			sql_string = fmt::format("CREATE UNIQUE INDEX t{}_4 ON t{} (inst_id)", table_id, table_id);
-		else
-			sql_string = fmt::format("CREATE INDEX t{}_4 ON t{} (inst_id)", table_id, table_id);
-		if (db.eph_exec(sql_string) != SQLITE_OK)
-			return false;
 		sql_string = "INSERT INTO stbl VALUES (?";
 		for (size_t i = 0; i < tag_count; ++i)
 			sql_string += ", ?";
@@ -1077,6 +1057,30 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 		stmt_cache.clear();
 		pstmt.finalize();
 		pstmt1.finalize();
+		/*
+		 * These serve later table operations; nothing above reads t{}
+		 * through them.
+		 */
+		if (ptnode->instance_tag == 0)
+			sql_string = fmt::format("CREATE UNIQUE INDEX t{}_4 ON t{} (inst_id)", table_id, table_id);
+		else
+			sql_string = fmt::format("CREATE INDEX t{}_4 ON t{} (inst_id)", table_id, table_id);
+		if (db.eph_exec(sql_string) != SQLITE_OK)
+			return false;
+		if (psorts->ccategories > 0) {
+			sql_string = fmt::format("CREATE UNIQUE INDEX t{}_1 ON "
+			             "t{} (inst_id, inst_num)", table_id, table_id);
+			if (db.eph_exec(sql_string) != SQLITE_OK)
+				return FALSE;
+			sql_string = fmt::format("CREATE INDEX t{}_2 ON"
+			             " t{} (parent_id)", table_id, table_id);
+			if (db.eph_exec(sql_string) != SQLITE_OK)
+				return FALSE;
+			sql_string = fmt::format("CREATE INDEX t{}_3 ON t{}"
+			             " (parent_id, value)", table_id, table_id);
+			if (db.eph_exec(sql_string) != SQLITE_OK)
+				return FALSE;
+		}
 		if (psort_transact.commit() != SQLITE_OK)
 			return false;
 		sqlite3_close_v2(psqlite);
@@ -1126,6 +1130,17 @@ static bool table_load_content_table(db_conn &db, db_base_wr_ptr &dbase,
 				return false;
 		}
 	}
+	/*
+	 * idx and prev_id are only consulted once the table is complete.
+	 */
+	sql_string = fmt::format("CREATE UNIQUE INDEX t{}_5 ON t{} (idx)",
+	             table_id, table_id);
+	if (db.eph_exec(sql_string) != SQLITE_OK)
+		return FALSE;
+	sql_string = fmt::format("CREATE UNIQUE INDEX t{}_6 ON t{} (prev_id)",
+	             table_id, table_id);
+	if (db.eph_exec(sql_string) != SQLITE_OK)
+		return FALSE;
 	cl_0.release();
 	if (table_transact.commit() != SQLITE_OK)
 		return false;

--- a/include/gromox/exmdb_common_util.hpp
+++ b/include/gromox/exmdb_common_util.hpp
@@ -99,7 +99,7 @@ BOOL common_util_get_folder_by_name(
 	sqlite3 *psqlite, uint64_t parent_id,
 	const char *str_name, uint64_t *pfolder_id);
 extern bool cu_msg_is_fai(const db_conn &, uint64_t msgid);
-extern bool cu_get_msg_flags(const db_conn &, uint64_t msg_id, bool b_native, uint32_t **out);
+extern bool cu_get_msg_flags(const db_conn &, uint64_t msg_id, bool b_native, uint32_t **out, uint32_t want = UINT32_MAX);
 extern std::string cu_cid_path(const char *dir, const char *cid, unsigned int type);
 extern int cu_set_message_read(sqlite3 *, uint64_t msg_id, bool is_read);
 BINARY* common_util_username_to_addressbook_entryid(

--- a/include/gromox/exmdb_common_util.hpp
+++ b/include/gromox/exmdb_common_util.hpp
@@ -98,7 +98,7 @@ uint64_t common_util_get_folder_parent_fid(
 BOOL common_util_get_folder_by_name(
 	sqlite3 *psqlite, uint64_t parent_id,
 	const char *str_name, uint64_t *pfolder_id);
-extern bool cu_msg_is_fai(sqlite3 *, uint64_t msgid);
+extern bool cu_msg_is_fai(const db_conn &, uint64_t msgid);
 extern bool cu_get_msg_flags(const db_conn &, uint64_t msg_id, bool b_native, uint32_t **out);
 extern std::string cu_cid_path(const char *dir, const char *cid, unsigned int type);
 extern int cu_set_message_read(sqlite3 *, uint64_t msg_id, bool is_read);


### PR DESCRIPTION
## What is slow

Opening a big folder in Outlook makes the server build a list of every mail in it before it can answer. On a 400,000-mail folder that took about 6.8 seconds for the normal date-sorted view and about 34 seconds with conversation view on, and a view filtered on unread took about 10 seconds. Outlook shows "not responding" for that whole time.

Ten changes. Each was measured on its own, and each was checked to leave the resulting table exactly as it was.

## The changes

1. **Do not build the whole list just to count it.** To say how many mails a folder holds, the server lined every mail up, counted the line and threw it away; counting the mails directly gives the same number. Search folders genuinely need the line-up and keep it. `ropGetContentsTable` 5292 ms to 80 ms.
2. **Answer "where am I in the list?" without building the list.** The cursor position is already tracked and the folder size is one cheap count. `ropQueryPosition` 2517 ms to 41 ms.
3. **Switch on the statement cache while loading.** The load asks for one property at a time, hundreds of thousands of times, and each ask was explained to the database from scratch. `query_content` already takes this cache for the same reason.
4. **Ask "is this mail read?" with a placeholder** instead of writing the mail's number into the query text, which stopped the database ever reusing it. 4.5 us down to 2.5 us, once per mail.
5. **Reuse the per-group queries.** Grouping mails asks almost the same question once per group, 400k times; it only varies with grouping depth. 2176 ms to 23 ms.
6. **Build the ephemeral table's indexes after the rows are in,** rather than filing every row into six of them on the way. Inserting rows 6101 ms to 2454 ms, plus 1205 ms to build the indexes.
7. **Take group unread counts from the grouping query.** Each header was written, then all its mails walked to count unread ones, then the header corrected. The grouping query can sum them itself. 19.76 s to 18.66 s over six runs.
8. **Insert rows in batches of 128** where the numbering is predictable. Restricted, filtered and sorted loads keep the row-at-a-time path, because they can skip rows and so cannot predict it.
9. **Cache the attachment and association probes.** Both wrote the mail's number into the query text, so a filtered load paid 800k query preparations. 10.50 s to 7.79 s.
10. **Only work out the message flags a filter actually looks at.** PR_MESSAGE_FLAGS is not stored as one value; it costs one lookup per flag bit. A filter on unread reads a single bit but paid for all six on every mail. 7.42 s to 1.75 s.

## Result

Server time for one folder open, `rop_debug = 2`, Outlook client, 399,986-mail folder:

| view | before | after |
|---|---|---|
| normal, date sorted | 6794 ms | about 1770 ms |
| conversation view | 33633 ms | about 20500 ms |
| filtered on unread | 10504 ms | 1750 ms |

What remains in conversation view is one build of a 400,000-group table, which is what that view asks for rather than a missing optimisation. The test mailbox holds one mail per conversation, which is the worst case for it; real mailboxes have fewer, larger conversations.

## Checking nothing changed

Every change was checked by hashing each column of each row of the resulting table and comparing with the commit before it, over six shapes: 501 groups of about 800 mails, 3 groups of about 133k, 400k single-mail groups, each collapsed and expanded, plus the flat and the filtered tables. Hashes are compared in row order and order-independently, and the columns include the computed ones (PR_MESSAGE_FLAGS, PR_HASATTACH, PR_ASSOCIATED, PR_CONTENT_UNREAD) so that a change in how those are worked out would show up. All identical.

One gap worth stating: the public-store adjustment that forces the read flag moves into cu_get_msg_flags in the last commit. The test store is a private one, so that line is verified as code motion rather than by measurement.