### PR TITLE
rtf: keep HTML character references intact when de-encapsulating

### DIFF
--- a/lib/mapi/rtf.cpp
+++ b/lib/mapi/rtf.cpp
@@ -409,6 +409,36 @@ bool rtf_reader::riconv_open(const char *fromcode)
 	return true;
 }
 
+/**
+ * Test whether @s starts an HTML character reference ("&lt;", "&#33;",
+ * "&#x2014;"). @len bounds the lookahead to the current text chunk, so a
+ * reference split across two chunks reads as a plain ampersand.
+ */
+static bool rtf_entity_ref_start(const char *s, size_t len)
+{
+	if (len < 4 || s[0] != '&')
+		return false;
+	size_t i = 1, start;
+	if (s[i] != '#') {
+		if (!HX_isalpha(s[i]))
+			return false;
+		start = i;
+		for (; i < len && i - start < 32 && HX_isalnum(s[i]); ++i)
+			;
+		return i - start >= 2 && i < len && s[i] == ';';
+	}
+	if (++i < len && (s[i] == 'x' || s[i] == 'X')) {
+		start = ++i;
+		for (; i < len && i - start < 6 && HX_isxdigit(s[i]); ++i)
+			;
+	} else {
+		start = i;
+		for (; i < len && i - start < 7 && HX_isdigit(s[i]); ++i)
+			;
+	}
+	return i > start && i < len && s[i] == ';';
+}
+
 bool rtf_reader::escape_output(char *string)
 {
 	auto preader = this;
@@ -439,7 +469,21 @@ bool rtf_reader::escape_output(char *string)
 			QRF(ext_push.p_bytes("&gt;"));
 			break;
 		case '&':
-			QRF(ext_push.p_bytes("&amp;"));
+			/*
+			 * Text runs of an encapsulated document may carry HTML
+			 * source rather than decoded text. Escaping a
+			 * character reference in such a run once more yields
+			 * "&amp;lt;", which the reader then displays as the
+			 * literal text "&lt;" instead of "<".
+			 * [MS-OXRTFEX] §2.1.3.2 keeps character references in
+			 * \*\htmltag destinations, so a conformant document
+			 * never arrives here with one.
+			 */
+			if (preader->have_fromhtml &&
+			    rtf_entity_ref_start(&string[i], tmp_len - i))
+				QRF(ext_push.p_uint8('&'));
+			else
+				QRF(ext_push.p_bytes("&amp;"));
 			break;
 		default:
 			QRF(ext_push.p_uint8(string[i]));

--- a/tests/bodyconv.cpp
+++ b/tests/bodyconv.cpp
@@ -95,6 +95,72 @@ static int t_rtf_reader()
 	return 0;
 }
 
+static const char rtf_native_angles[] =
+"{\\rtf1\\ansi\\ansicpg1252\\deff0{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}"
+"\\plain Von: Katja Test <katja@dev.local>}";
+
+static const char rtf_fromhtml_conformant[] =
+"{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\deff0{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}"
+"{\\*\\htmltag19 <html>}{\\*\\htmltag34 <body>}{\\*\\htmltag64 <p>}"
+"Von: Katja Test {\\*\\htmltag84 &lt;}\\htmlrtf <\\htmlrtf0 katja@dev.local"
+"{\\*\\htmltag84 &gt;}\\htmlrtf >\\htmlrtf0 {\\*\\htmltag72 </p>}"
+"{\\*\\htmltag41 </body>}{\\*\\htmltag27 </html>}}";
+
+static const char rtf_fromhtml_srctext[] =
+"{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\deff0{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}"
+"{\\*\\htmltag19 <html>}{\\*\\htmltag34 <body>}{\\*\\htmltag64 <p>}"
+"Von: Katja Test &lt;katja@dev.local&gt;{\\*\\htmltag72 </p>}"
+"{\\*\\htmltag41 </body>}{\\*\\htmltag27 </html>}}";
+
+static const char rtf_fromhtml_srctext_anchor[] =
+"{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\deff0{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}"
+"{\\*\\htmltag19 <html>}{\\*\\htmltag34 <body>}{\\*\\htmltag64 <p>}"
+"{\\*\\htmltag84 <b>}Von:{\\*\\htmltag92 </b>} Katja Test &lt;"
+"{\\*\\htmltag84 <a href=\"mailto:katja@dev.local\">}katja@dev.local{\\*\\htmltag92 </a>}"
+"&gt;{\\*\\htmltag72 </p>}{\\*\\htmltag41 </body>}{\\*\\htmltag27 </html>}}";
+
+static const char rtf_fromhtml_numeric[] =
+"{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\deff0{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}"
+"{\\*\\htmltag19 <html>}{\\*\\htmltag34 <body>}{\\*\\htmltag64 <p>}"
+"a&#33;b&#x2014;c{\\*\\htmltag72 </p>}{\\*\\htmltag41 </body>}{\\*\\htmltag27 </html>}}";
+
+static const char rtf_fromhtml_bare_amp[] =
+"{\\rtf1\\ansi\\ansicpg1252\\fromhtml1\\deff0{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}"
+"{\\*\\htmltag19 <html>}{\\*\\htmltag34 <body>}{\\*\\htmltag64 <p>}"
+"Meier & Sohn, A&B, 100&#37, x&y;{\\*\\htmltag72 </p>}{\\*\\htmltag41 </body>}"
+"{\\*\\htmltag27 </html>}}";
+
+/*
+ * Text runs of a \\fromhtml1 document are HTML source in some producers and
+ * decoded text in others; markup always lives in \\*\\htmltag destinations and
+ * is emitted verbatim. Escaping has to leave character references alone
+ * without letting a bare ampersand through.
+ */
+static int t_fromhtml_entities()
+{
+	auto ret = rp_thtml(rtf_native_angles, "&lt;katja@dev.local&gt;");
+	if (ret != 0)
+		return ret;
+	ret = rp_thtml(rtf_fromhtml_conformant, "Von: Katja Test &lt;katja@dev.local&gt;");
+	if (ret != 0)
+		return ret;
+	ret = rp_thtml(rtf_fromhtml_srctext, "Von: Katja Test &lt;katja@dev.local&gt;");
+	if (ret != 0)
+		return ret;
+	ret = rp_thtml(rtf_fromhtml_srctext_anchor,
+	      "&lt;<a href=\"mailto:katja@dev.local\">katja@dev.local</a>&gt;");
+	if (ret != 0)
+		return ret;
+	ret = rp_thtml(rtf_fromhtml_numeric, "a&#33;b&#x2014;c");
+	if (ret != 0)
+		return ret;
+	ret = rp_thtml(rtf_fromhtml_bare_amp,
+	      "Meier &amp; Sohn, A&amp;B, 100&amp;#37, x&amp;y;");
+	if (ret != 0)
+		return ret;
+	return 0;
+}
+
 static int t_html_plain()
 {
 	std::string obuf;
@@ -129,6 +195,8 @@ int main()
 	if (t_html_plain() != 0)
 		return EXIT_FAILURE;
 	if (t_rtf_reader() != 0)
+		return EXIT_FAILURE;
+	if (t_fromhtml_entities() != 0)
 		return EXIT_FAILURE;
 	if (t_htmltortf() != 0)
 		return EXIT_FAILURE;


### PR DESCRIPTION
### Problem

Some mails de-encapsulate with their HTML character references escaped a second time, so a quoted mail header arrives in the reader as `Von: Katja Test &lt;katja@example.com&gt;` — the literal text `&lt;` is displayed where `<` belongs.

The markup around it is unaffected: labels stay bold and addresses stay live `mailto:` links. That combination is the whole diagnostic — text was escaped, tags were not, so an `&` was escaped once too often rather than a tag being mangled.

### Cause

`rtf_reader::escape_output()` gates escaping on `is_within_htmltag` and never on `have_fromhtml`. Inside a `{\*\htmltag...}` destination the bytes are written out verbatim, which is why the surrounding markup survives; outside one, every `<`, `>` and `&` is escaped. When a producer puts HTML source rather than decoded text into an ordinary text run of a `\fromhtml1` document, that run's `&lt;` is emitted as `&amp;lt;`.

The path matters beyond display, because the same converter feeds `skel_grab_rtf()` when the outgoing MIME `text/html` part is built from RTF, so the doubled reference can be baked into mail leaving the system.

### Change

The `&` case emits the ampersand verbatim when the document is encapsulated HTML and the ampersand begins a syntactically valid character reference (`&name;` with 2 to 32 name characters, `&#digits;`, or `&#x hex digits;`). Everything else escapes exactly as before, and `<` and `>` are untouched.

Lookahead is bounded by the current text chunk, so a reference split across two `escape_output()` calls simply falls back to the previous behaviour instead of emitting a partial reference.

### Tests

`tests/bodyconv.cpp` gains six cases covering both directions:

- native RTF with literal angle brackets — must still be escaped
- `\fromhtml1` with the reference in a `\*\htmltag` destination and the character in an `\htmlrtf`-suppressed run, i.e. the conformant shape from §3.1
- `\fromhtml1` with escaped HTML source as an ordinary text run
- the same with a bold label and a `mailto:` anchor, which is the shape seen in the wild
- numeric and hexadecimal references (`&#33;`, `&#x2014;`)
- a negative control: `Meier & Sohn, A&B, 100&#37, x&y;` must still escape every ampersand, none of which starts a valid reference


