### PR TITLE
ews: enforce Send-As permission on client-supplied From/Sender

### DIFF
--- a/exch/ews/context.cpp
+++ b/exch/ews/context.cpp
@@ -3314,6 +3314,35 @@ uint32_t EWSContext::permissions(const std::string& maildir, uint64_t folderId) 
 }
 
 /**
+ * @brief      Verify the caller may claim a given identity as sender
+ *
+ * @param      identity   SMTP address the message claims to be sent from
+ *
+ * @throw      EWSError::AccessDenied   Caller lacks Send-As rights on
+ *              the claimed identity
+ */
+void EWSContext::validate_sendas_perms(const std::string &identity) const
+{
+	if (identity.empty() ||
+	    strcasecmp(identity.c_str(), m_auth_info.username) == 0)
+		return; /* claiming to be yourself never needs a grant */
+	std::string maildir;
+	try {
+		maildir = get_maildir(identity);
+	} catch (...) {
+		/* Unresolvable (external/nonexistent) address is never a valid Send-As target */
+		throw EWSError::AccessDenied(E3474);
+	}
+	if (maildir == m_auth_info.maildir)
+		return; /* alias of the caller's own mailbox */
+	uint32_t permission = 0;
+	if (!m_plugin.exmdb.get_mbox_perm(maildir.c_str(),
+	    m_auth_info.username, &permission) ||
+	    !(permission & (frightsGromoxSendAs | frightsGromoxStoreOwner)))
+		throw EWSError::AccessDenied(E3474);
+}
+
+/**
  * @brief      Read delegate permissions from folder ACLs
  */
 tDelegatePermissions EWSContext::readDelegatePermissions(const std::string &dir, const std::string &username) const

--- a/exch/ews/ews.hpp
+++ b/exch/ews/ews.hpp
@@ -335,6 +335,7 @@ class EWSContext {
 	void normalize(Structures::tMailbox&) const;
 	int notify();
 	uint32_t permissions(const std::string&, uint64_t) const;
+	void validate_sendas_perms(const std::string &) const;
 	Structures::tDelegatePermissions readDelegatePermissions(const std::string&, const std::string&) const;
 	Structures::sFolderSpec resolveFolder(const Structures::tDistinguishedFolderId&) const;
 	Structures::sFolderSpec resolveFolder(const Structures::tFolderId&) const;

--- a/exch/ews/exceptions.hpp
+++ b/exch/ews/exceptions.hpp
@@ -602,6 +602,7 @@ E(3470, "only the organizer can cancel a meeting");
 E(3471, "failed to delete cancelled meeting");
 E(3472, "cannot read from item's source folder");
 E(3473, "cannot write to destination folder");
+E(3474, "access denied: missing Send-As permission on the claimed sender identity");
 
 #undef E
 }

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -746,6 +746,10 @@ void process(mCreateItemRequest &&request, XMLElement *response, const EWSContex
 			}
 		}
 
+		/* Verify the caller has Send-As rights on this identity, else throw */
+		if (auto claimed = content->proplist.get<const char>(PR_SENT_REPRESENTING_EMAIL_ADDRESS))
+			ctx.validate_sendas_perms(claimed);
+
 		auto updateRef = [&](const tItemId &refId, uint32_t resp) {
 			ctx.assertIdType(refId.type, tItemId::ID_ITEM);
 			sMessageEntryId mid(refId.Id.data(), refId.Id.size());


### PR DESCRIPTION
Sorry, missed something in #286 that I should have caught then. Found and fixed a permission gap in EWS's `CreateItem` while looking into something unrelated (a "Send As" convenience script on our own deployment). `toContent()` writes whatever identity a client supplies via a message's From/Sender field straight into `PR_SENT_REPRESENTING_*`/`PR_SENDER_*`, for both `SaveOnly` and `SendOnly`/`SendAndSaveCopy` - with no authorization check.

Root cause: #286 ("respect client-supplied From on save") intentionally started trusting a client-supplied From to fix a real bug - a draft saved from a secondary alias reverting to the primary identity - and explicitly modeled this on grommunio-web's `PR_SENT_REPRESENTING_* ??= PR_SENDER_*` pattern (`class.operations.php`). It only carried over the fallback-default half of that pattern, not the permission check that makes it safe there.

Fix adds `EWSContext::checkSendAs()`, mirroring `zs_submitmessage()`'s check (`frightsGromoxSendAs` or full store ownership on the claimed identity's mailbox), called from `CreateItem` right after `toContent()` populates `PR_SENT_REPRESENTING_EMAIL_ADDRESS` - applies uniformly to drafts and actual sends, and to the reply/forward wrapper types alongside plain messages.

Tested against a live deployment: granted a real `frightsGromoxSendAs` grant between two test mailboxes, confirmed a `CreateItem` with the granted identity still succeeds and correctly resolves to it, confirmed the same request with an ungranted identity now gets `ErrorAccessDenied`, and confirmed a plain message with no From override is unaffected.