### PR TITLE
oxcmail: do not drop HTML bodies that are not the first subpart

### DIFF
--- a/lib/mapi/oxcmail2.cpp
+++ b/lib/mapi/oxcmail2.cpp
@@ -117,6 +117,16 @@ void select_parts(const MIME *part, MIME_ENUM_PARAM &info, unsigned int level) t
 		if (hjoin_enabled) {
 			info.htmls.insert(info.htmls.end(), std::make_move_iterator(cld_info.htmls.begin()), std::make_move_iterator(cld_info.htmls.end()));
 			info.hjoin.insert(info.hjoin.end(), std::make_move_iterator(cld_info.hjoin.begin()), std::make_move_iterator(cld_info.hjoin.end()));
+		} else if (info.htmls.empty() && !cld_info.htmls.empty()) {
+			/*
+			 * The HTML body is not required to sit in the very
+			 * first subpart; an attachment, a text part or an
+			 * image can precede it. Joining is not applicable
+			 * here (that is what hjoin_enabled selects), but the
+			 * body must still be picked up rather than dropped.
+			 */
+			info.htmls = std::move(cld_info.htmls);
+			info.hjoin = std::move(cld_info.hjoin);
 		}
 		if (cld_info.penriched != nullptr && info.penriched == nullptr)
 			info.penriched = std::move(cld_info.penriched);

--- a/tests/oxcmail_ie.cpp
+++ b/tests/oxcmail_ie.cpp
@@ -404,6 +404,134 @@ static int select_parts_5()
 	return 0;
 }
 
+static char data_6[] =
+	"Content-Type: multipart/mixed; boundary=\"0\"\r\n"
+	"MIME-Version: 1.0\r\n"
+	"\r\n"
+	"--0\r\n"
+	"Content-Type: application/pdf; name=\"a.pdf\"\r\n"
+	"Content-Disposition: attachment; filename=\"a.pdf\"\r\n"
+	"\r\n"
+	"PDF\r\n"
+	"--0\r\n"
+	"Content-Type: multipart/alternative; boundary=\"1\"\r\n"
+	"\r\n"
+	"--1\r\n"
+	"Content-Type: text/plain; charset=\"utf-8\"\r\n"
+	"\r\n"
+	"ZplainZ\r\n"
+	"--1\r\n"
+	"Content-Type: text/html; charset=\"utf-8\"\r\n"
+	"\r\n"
+	"Zhtml1Z\r\n"
+	"--1--\r\n"
+	"--0--\r\n";
+static char data_7[] =
+	"Content-Type: multipart/mixed; boundary=\"0\"\r\n"
+	"MIME-Version: 1.0\r\n"
+	"\r\n"
+	"--0\r\n"
+	"Content-Type: application/pdf; name=\"a.pdf\"\r\n"
+	"Content-Disposition: attachment; filename=\"a.pdf\"\r\n"
+	"\r\n"
+	"PDF\r\n"
+	"--0\r\n"
+	"Content-Type: text/html; charset=\"utf-8\"\r\n"
+	"\r\n"
+	"Zhtml1Z\r\n"
+	"--0--\r\n";
+static char data_8[] =
+	"Content-Type: multipart/mixed; boundary=\"0\"\r\n"
+	"MIME-Version: 1.0\r\n"
+	"\r\n"
+	"--0\r\n"
+	"Content-Type: text/plain; charset=\"utf-8\"\r\n"
+	"\r\n"
+	"ZplainZ\r\n"
+	"--0\r\n"
+	"Content-Type: text/html; charset=\"utf-8\"\r\n"
+	"\r\n"
+	"Zhtml1Z\r\n"
+	"--0--\r\n";
+
+/*
+ * The HTML body may be preceded by other parts. Ensure it is still used as
+ * the body rather than being demoted to an attachment (which would leave
+ * PR_HTML to be autosynthesized from plaintext later on).
+ */
+static int select_parts_6()
+{
+	fprintf(stderr, "== T6\n");
+	MAIL m;
+	assert(m.refonly_parse(data_6, std::size(data_6)));
+
+	oxcmail_converter cvt;
+	cvt.alloc = g_alloc;
+	cvt.get_propids = ee_get_propids;
+	auto mc = cvt.inet_to_mapi(m);
+	assert(mc != nullptr);
+	auto atl = mc->children.pattachments;
+	if (atl == nullptr || atl->count != 1)
+		gi_print(0, *mc);
+	assert(atl != nullptr && atl->count == 1);
+	auto v = atl->pplist[0]->proplist.get<const char>(PR_ATTACH_MIME_TAG);
+	assert(v != nullptr && strcasecmp(v, "application/pdf") == 0);
+	v = mc->proplist.get<const char>(PR_BODY);
+	assert(v != nullptr && strcmp(v, "ZplainZ") == 0);
+	auto bin = mc->proplist.get<const BINARY>(PR_HTML);
+	assert(bin != nullptr);
+	assert(HX_memmem(bin->pv, bin->cb, "Zhtml1Z", 7) != nullptr);
+	return 0;
+}
+
+/* Same, but without any text/plain alternative to fall back to. */
+static int select_parts_7()
+{
+	fprintf(stderr, "== T7\n");
+	MAIL m;
+	assert(m.refonly_parse(data_7, std::size(data_7)));
+
+	oxcmail_converter cvt;
+	cvt.alloc = g_alloc;
+	cvt.get_propids = ee_get_propids;
+	auto mc = cvt.inet_to_mapi(m);
+	assert(mc != nullptr);
+	auto atl = mc->children.pattachments;
+	if (atl == nullptr || atl->count != 1)
+		gi_print(0, *mc);
+	assert(atl != nullptr && atl->count == 1);
+	auto v = atl->pplist[0]->proplist.get<const char>(PR_ATTACH_MIME_TAG);
+	assert(v != nullptr && strcasecmp(v, "application/pdf") == 0);
+	auto bin = mc->proplist.get<const BINARY>(PR_HTML);
+	assert(bin != nullptr);
+	assert(HX_memmem(bin->pv, bin->cb, "Zhtml1Z", 7) != nullptr);
+	return 0;
+}
+
+/* Some MUAs emit alternative bodies in a mixed container. */
+static int select_parts_8()
+{
+	fprintf(stderr, "== T8\n");
+	MAIL m;
+	assert(m.refonly_parse(data_8, std::size(data_8)));
+
+	oxcmail_converter cvt;
+	cvt.alloc = g_alloc;
+	cvt.get_propids = ee_get_propids;
+	auto mc = cvt.inet_to_mapi(m);
+	assert(mc != nullptr);
+	auto atl = mc->children.pattachments;
+	if (atl != nullptr && atl->count != 0)
+		gi_print(0, *mc);
+	assert(atl == nullptr || atl->count == 0);
+	auto v = mc->proplist.get<const char>(PR_BODY);
+	assert(v != nullptr && strcmp(v, "ZplainZ") == 0);
+	auto bin = mc->proplist.get<const BINARY>(PR_HTML);
+	assert(bin != nullptr);
+	assert(HX_memmem(bin->pv, bin->cb, "Zhtml1Z", 7) != nullptr);
+	return 0;
+}
+
 static int ical_export_1()
 {
 	/*
@@ -532,6 +660,7 @@ int main()
 	int ret = EXIT_SUCCESS;
 	for (auto fct : {excess_attachment, select_parts_1, select_parts_1a,
 	     select_parts_2, select_parts_3, select_parts_4, select_parts_5,
+	     select_parts_6, select_parts_7, select_parts_8,
 	     ical_export_1, ical_export_2, hdrparse_1})
 		if (fct() != EXIT_SUCCESS)
 			ret = EXIT_FAILURE;


### PR DESCRIPTION
`select_parts()` only adopts HTML parts when the **first** child of a non-`multipart/alternative` container has already yielded one:

```c
if (child_idx == 0 && cld_info.htmls.size() > 0)
        hjoin_enabled = true;
...
if (hjoin_enabled) {
        info.htmls.insert(...);
        info.hjoin.insert(...);
}
```

`hjoin_enabled` is meant to select whether *multiple* HTML parts get joined (introduced in aa745b88e for the EXC-style multi-HTML case), but it also gates whether *any* HTML is picked up at all. An HTML body preceded by anything else — an attachment, a `text/plain` part, an inline image — is discarded and demoted to an attachment. `PR_HTML` is then autosynthesized from the plaintext body and wrapped in `<pre>`, so the message presents as plaintext. Where no `text/plain` part exists either, the message ends up with **no body at all**.

Containers whose first child carries the HTML are unaffected, which is why this is not more widely visible.

## Affected shapes

Measured against `tests/oxcmail_ie` before the change:

| MIME structure | before | after |
|---|---|---|
| `mixed{ alternative{plain,html}, pdf }` | HTML ok | HTML ok (unchanged) |
| `mixed{ pdf, alternative{plain,html} }` | `<pre>` plaintext, HTML → attachment | HTML ok |
| `mixed{ plain-disclaimer, alternative{plain,html} }` | `<pre>` plaintext, HTML → attachment | HTML ok |
| `related{ inline image, alternative{plain,html} }` | `<pre>` plaintext, HTML → attachment | HTML ok |
| `mixed{ plain, html }` | `<pre>` plaintext, HTML → attachment | HTML ok |
| `mixed{ pdf, html }` | **no body at all** | HTML ok |
