### PR TITLE
g-timer: Fix incorrect event insertion into timer-state file:

### DIFF
--- a/tools/timer.cpp
+++ b/tools/timer.cpp
@@ -190,7 +190,7 @@ static TIMER *put_timer(TIMER &&ptimer)
 		std::list<TIMER> stash;
 		stash.push_back(std::move(ptimer));
 		g_exec_list.splice(pos, stash, stash.begin());
-		return &*pos;
+		return &*--pos;
 	}
 	g_exec_list.push_back(std::move(ptimer));
 	return &g_exec_list.back();


### PR DESCRIPTION
`put_timer(TIMER&&) `is expected to return a ptr to the queued timer object. For an ADD-request, `tmr_thrwork_1` subsequently uses this reference to append the newly created list member to timer-state-file `timer.txt`. This works as expected if the newly created event is pushed back to `g_exec_list` (=expires latest of all existing events). However, if a newly created timer-entry expires earlier than existing timers, it must be inserted into `g_exec_list` (`splice`). In this case, current implementation returns a reference to the **predessor**-event (instead of the new element). This predecessor is then duplicated within the state file, wheres the newly created/inserted entry is never saved and gets lost latest with next restart of g-timer.