### PR TITLE
imap: fix check for null in parse_imap_seq

### DIFF
--- a/mra/imap/cmd.cpp
+++ b/mra/imap/cmd.cpp
@@ -3068,9 +3068,12 @@ int icp_search(std::span<std::string> argv, imap_context &ctx)
 static errno_t parse_imap_seqx(imap_context &ctx, const char *range_string,
     imap_seq_list &uid_list) try
 {
+	if (range_string == nullptr)
+		return EINVAL;
+
 	/* SEARCHRES: expand "$" against the saved result (sequence numbers). */
 	std::string subst;
-	if (range_string != nullptr && strchr(range_string, '$') != nullptr) {
+	if (strchr(range_string, '$') != nullptr) {
 		subst = range_string;
 		icp_subst_searchres(ctx, subst, false);
 		range_string = subst.c_str();


### PR DESCRIPTION
Fixing coverity issue 1663921.
Ensure that range_string pointer won't be dereferenced if it's null.
