### PR TITLE
lda: derive an out-of-office reply subject when none is stored

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,16 @@ Schedule
 It's ready when it's ready.
 
 
+Development 3.10.10
+===================
+
+Enhancements:
+
+* lda: out-of-office replies now derive a subject from the incoming message
+  when the mailbox has none stored, e.g. when OOF is set over EWS.
+  The new config directive gromox.cfg:``autoreply_subject_prefix`` was added.
+
+
 Gromox 3.10 (2026-08-22)
 ========================
 

--- a/doc/exmdb_local.4gx
+++ b/doc/exmdb_local.4gx
@@ -13,6 +13,9 @@ The usual config file location is /etc/gromox/exmdb_local.cfg.
 \fBautoreply_silence_window\fP
 -> See gromox.cfg(5) manpage instead!
 .TP
+\fBautoreply_subject_prefix\fP
+-> See gromox.cfg(5) manpage instead!
+.TP
 \fBcache_scan_interval\fP
 Interval in which to scan /var/lib/gromox/queue/cache.
 .br

--- a/doc/gromox.cfg.5
+++ b/doc/gromox.cfg.5
@@ -22,6 +22,15 @@ stored persistently, in the message database.)
 .br
 Default: \fI1day\fP
 .TP
+\fBautoreply_subject_prefix\fP
+Out-of-office replies use the subject that was set alongside the OOF message.
+Clients which configure OOF over EWS cannot set one, because
+SetUserOofSettings has no field for it. When no subject is stored, this prefix
+plus the subject of the incoming message is used instead. Set to the empty
+string to send such replies without a subject.
+.br
+Default: \fIOut of Office: \fP
+.TP
 \fBbackfill_transport_headers\fP
 Try to fill the PR_TRANSPORT_MESSAGE_HEADERS property when messages are
 submitted.

--- a/mda/exmdb_local/auto_response.cpp
+++ b/mda/exmdb_local/auto_response.cpp
@@ -3,6 +3,7 @@
 // This file is part of Gromox.
 #include <cstdint>
 #include <cstring>
+#include <string>
 #include <libHX/string.h>
 #include <vmime/addressList.hpp>
 #include <vmime/dateTime.hpp>
@@ -21,6 +22,7 @@ using namespace gromox;
 DECLARE_HOOK_API(exmdb_local, extern);
 using namespace exmdb_local;
 unsigned int autoreply_silence_window;
+std::string autoreply_subject_prefix;
 
 static int is_same_org(const char *a, const char *b)
 {
@@ -36,9 +38,10 @@ static int is_same_org(const char *a, const char *b)
  * @user_home: Maildir for basically @rcpt
  * @from:      Sender for the autoresponse (Original Envelope-To)
  * @rcpt:      Recipient for the autoresponse (Original Envelope-From)
+ * @orig_subject: Subject of the message that triggered the autoresponse
  */
-void auto_response_reply(const char *user_home,
-    const char *from, const char *rcpt) try
+void auto_response_reply(const char *user_home, const char *from,
+    const char *rcpt, std::string &&orig_subject) try
 {
 	auto same_org = is_same_org(from, rcpt);
 	if (same_org < 0)
@@ -87,8 +90,25 @@ void auto_response_reply(const char *user_home,
 		}
 	}
 
+	std::string subject_buf;
 	auto subject_text = znul(ar_props.get<const char>(same_org ? PR_EC_OUTOFOFFICE_SUBJECT : PR_EC_EXTERNAL_SUBJECT));
 	auto message_text = znul(ar_props.get<const char>(same_org ? PR_EC_OUTOFOFFICE_MSG : PR_EC_EXTERNAL_REPLY));
+	/*
+	 * EWS's SetUserOofSettings has no field for a reply subject. Clients
+	 * using EWS leave PR_EC_*_SUBJECT untouched. Derive one from the
+	 * incoming message rather than emitting an empty Subject header.
+	 */
+	if (*subject_text == '\0' && !autoreply_subject_prefix.empty()) {
+		subject_buf = autoreply_subject_prefix;
+		if (orig_subject.size() > 0) {
+			subject_buf += std::move(orig_subject);
+		} else {
+			/* Drop the separator when there is nothing to append. */
+			auto end = subject_buf.find_last_not_of(" :");
+			subject_buf.erase(end == subject_buf.npos ? 0 : end + 1);
+		}
+		subject_text = subject_buf.c_str();
+	}
 	auto vpctx = vmail_default_parsectx();
 	vmime::message vmsg;
 

--- a/mda/exmdb_local/exmdb_local.cpp
+++ b/mda/exmdb_local/exmdb_local.cpp
@@ -405,6 +405,7 @@ delivery_status exmdb_local_deliverquota(MESSAGE_CONTEXT *pcontext,
 	}
 
 	auto dm_status = static_cast<deliver_message_result>(r32);
+	std::string orig_subject;
 	if (dm_status == deliver_message_result::result_ok) {
 		/* XXX: still need to make partial_ok behavior configurable */
 		auto num = pmsg->proplist.get<const uint32_t>(PR_AUTO_RESPONSE_SUPPRESS);
@@ -444,6 +445,8 @@ delivery_status exmdb_local_deliverquota(MESSAGE_CONTEXT *pcontext,
 		    message_id, &rbct) && rbct != nullptr)
 			lq_report(pcontext->ctrl.queue_ID, rop_util_get_gc_value(message_id),
 				"after_delivery", *rbct);
+		if (!(suppress_mask & AUTO_RESPONSE_SUPPRESS_OOF))
+			orig_subject = znul(pmsg->proplist.get<const char>(PR_SUBJECT));
 	}
 	pmsg.reset();
 
@@ -454,7 +457,8 @@ delivery_status exmdb_local_deliverquota(MESSAGE_CONTEXT *pcontext,
 		if (pcontext->ctrl.need_bounce &&
 		    strcmp(pcontext->ctrl.from, ENVELOPE_FROM_NULL) != 0&&
 		    !(suppress_mask & AUTO_RESPONSE_SUPPRESS_OOF))
-			auto_response_reply(home_dir, address, pcontext->ctrl.from);
+			auto_response_reply(home_dir, address, pcontext->ctrl.from,
+				std::move(orig_subject));
 		break;
 	case deliver_message_result::partial_completion:
 		exmdb_local_log_info(pcontext->ctrl, address, LV_ERR,
@@ -518,6 +522,7 @@ void exmdb_local_log_info(const CONTROL_INFO &ctrl,
 
 static constexpr cfg_directive mdlgx_cfg_defaults[] = {
 	{"autoreply_silence_window", "1day", CFG_TIME, "0"},
+	{"autoreply_subject_prefix", "Out of office: "},
 	CFG_TABLE_END,
 };
 
@@ -540,6 +545,7 @@ bool HOOK_exmdb_local(enum plugin_op reason, const struct dlfuncs &ppdata)
 		auto cfg = config_file_initd("gromox.cfg", get_config_path(), mdlgx_cfg_defaults);
 		if (cfg != nullptr) {
 			autoreply_silence_window = cfg->get_ll("autoreply_silence_window");
+			autoreply_subject_prefix = znul(cfg->get_value("autoreply_subject_prefix"));
 			g_junk_rules = parse_junk_rules(cfg->get_value("lda_junk_rules"));
 		}
 

--- a/mda/exmdb_local/exmdb_local.hpp
+++ b/mda/exmdb_local/exmdb_local.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <ctime>
+#include <string>
 #include <gromox/common_types.hpp>
 #include <gromox/hook_common.h>
 
@@ -9,7 +10,7 @@ enum class delivery_status {
 
 struct MAIL;
 
-extern void auto_response_reply(const char *user_home, const char *from, const char *rcpt);
+extern void auto_response_reply(const char *user_home, const char *from, const char *rcpt, std::string &&orig_subject);
 
 extern void bounce_audit_init(int audit_num, int audit_interval);
 extern BOOL bounce_audit_check(const char *audit_string);
@@ -29,3 +30,4 @@ extern delivery_status exmdb_local_deliverquota(MESSAGE_CONTEXT *pcontext, const
 extern void exmdb_local_log_info(const CONTROL_INFO &, const char *rcpt, int level, const char *format, ...);
 
 extern unsigned int autoreply_silence_window;
+extern std::string autoreply_subject_prefix;


### PR DESCRIPTION
# Problem

An out-of-office reply can go out with a completely empty `Subject:` header, and this happens for every mailbox whose OOF was configured from Outlook.

`SetUserOofSettings` writes `PR_EC_OUTOFOFFICE`, `PR_EC_ALLOW_EXTERNAL`, `PR_EC_EXTERNAL_AUDIENCE`, `PR_EC_OUTOFOFFICE_FROM`/`UNTIL`, `PR_EC_OUTOFOFFICE_MSG` and `PR_EC_EXTERNAL_REPLY`, but never `PR_EC_OUTOFOFFICE_SUBJECT` or `PR_EC_EXTERNAL_SUBJECT` — the EWS `ReplyBody` type has only `Message` and `xml:lang`, so there is no reply subject to write. Autodiscover advertises `OOFUrl`, so EWS is the path Outlook takes, and gromox has no handling for the older `IPM.Note.Rules.OofTemplate.Microsoft` route at all.

`auto_response_reply()` then reads the subject through `znul()`, so an absent property becomes `""` and vmime emits an empty `Subject:` header. There is no fallback anywhere in the tree.

Two observable cases:

- a mailbox that only ever used Outlook for OOF sends replies with a blank subject
- a mailbox that once had a subject set through a web client keeps sending that stale subject after the text is changed in Outlook, because subject and body share one file and a body write preserves the existing header block

## Change

When no subject is stored, the reply subject is built from the new `gromox.cfg` directive `autoreply_subject_prefix` plus the subject of the message that triggered the reply. The incoming subject is captured in `exmdb_local_deliverquota()` before `pmsg` is released, and only when an OOF reply is still possible, so there is no extra allocation on the normal delivery path.

A stored subject is used unchanged, and setting the directive to the empty string restores the previous behaviour exactly.
