### PR TITLE
exmdb: make the statement cache fail soft

### DIFF
--- a/exch/exmdb/common_util.cpp
+++ b/exch/exmdb/common_util.cpp
@@ -440,7 +440,8 @@ bool db_conn::begin_optim() try
 		return true;
 	}
 	auto op = std::make_unique<prepared_statements>();
-	if (!op->begin(psqlite, exmdb_server::is_private()))
+	if (g_exmdb_enable_optim_stm &&
+	    !op->begin(psqlite, exmdb_server::is_private()))
 		return false;
 	m_prepstm = std::move(op);
 	return true;

--- a/exch/exmdb/common_util.cpp
+++ b/exch/exmdb/common_util.cpp
@@ -392,45 +392,35 @@ bool cu_eid_is_allocated(sqlite3 *psqlite, uint64_t eid_val, BOOL *pb_result)
 
 }
 
-bool prepared_statements::begin(sqlite3 *psqlite, bool pvt_store)
+/**
+ * Fill the statement cache. Every user of these statements prepares its own
+ * copy when the cached one is absent, so a member left null here costs speed
+ * and nothing else; gx_sql_prep has already logged the reason.
+ */
+void prepared_statements::begin(sqlite3 *psqlite, bool pvt_store)
 {
 	msg_norm = gx_sql_prep(psqlite, "SELECT propval"
 	               " FROM message_properties WHERE "
 	               "message_id=? AND proptag=?");
-	if (msg_norm == nullptr)
-		return FALSE;
 	msg_str = gx_sql_prep(psqlite, "SELECT proptag, "
 	              "propval FROM message_properties WHERE "
 	              "message_id=? AND proptag IN (?,?)");
-	if (msg_str == nullptr)
-		return FALSE;
 	rcpt_norm = gx_sql_prep(psqlite, "SELECT propval "
 	                "FROM recipients_properties WHERE "
 	                "recipient_id=? AND proptag=?");
-	if (rcpt_norm == nullptr)
-		return FALSE;
 	rcpt_str = gx_sql_prep(psqlite, "SELECT proptag, propval"
 	               " FROM recipients_properties WHERE recipient_id=?"
 	               " AND proptag IN (?,?)");
-	if (rcpt_str == nullptr)
-		return FALSE;
-	if (pvt_store) {
+	/* Public stores keep read state in read_states, not messages. */
+	if (pvt_store)
 		msg_read = gx_sql_prep(psqlite, "SELECT read_state FROM "
-			   "messages WHERE message_id=?");
-		if (msg_read == nullptr)
-			return false;
-	} else {
+		           "messages WHERE message_id=?");
+	else
 		msg_read.reset();
-	}
 	msg_atx = gx_sql_prep(psqlite, "SELECT 1 FROM attachments "
 	          "WHERE message_id=? LIMIT 1");
-	if (msg_atx == nullptr)
-		return false;
 	msg_fai = gx_sql_prep(psqlite, "SELECT is_associated FROM "
 	          "messages WHERE message_id=?");
-	if (msg_fai == nullptr)
-		return false;
-	return true;
 }
 
 bool db_conn::begin_optim() try
@@ -440,9 +430,8 @@ bool db_conn::begin_optim() try
 		return true;
 	}
 	auto op = std::make_unique<prepared_statements>();
-	if (g_exmdb_enable_optim_stm &&
-	    !op->begin(psqlite, exmdb_server::is_private()))
-		return false;
+	if (g_exmdb_enable_optim_stm)
+		op->begin(psqlite, exmdb_server::is_private());
 	m_prepstm = std::move(op);
 	return true;
 } catch (const std::bad_alloc &) {

--- a/exch/exmdb/db_engine.hpp
+++ b/exch/exmdb/db_engine.hpp
@@ -108,7 +108,7 @@ struct instance_node {
 };
 
 struct prepared_statements {
-	bool begin(sqlite3 *, bool pvt_store);
+	void begin(sqlite3 *, bool pvt_store);
 	gromox::xstmt msg_norm, msg_str, rcpt_norm, rcpt_str, msg_read,
 		msg_atx, msg_fai;
 };


### PR DESCRIPTION
### Problem

GXH-323 was a single statement that would not prepare, and it took public folders down with it. `prepared_statements::begin()` returns false on the first `gx_sql_prep` that fails, and all five callers of `db_conn::begin_optim()` turn that into a failed RPC: `exch/exmdb/table.cpp:1743`, `table.cpp:2222`, `exch/exmdb/message.cpp:3977`, `exch/exmdb/instance.cpp:483` and `exch/exmdb/db_engine.cpp:1748`. The store was intact and one lookup out of seven was wrong, but opening a public contact or calendar folder failed outright.

The cache is not load-bearing anywhere else. `cu_msg_is_fai`, `cu_msg_has_attachments` and `cu_msg_is_read` each prepare their own statement when the cached one is absent, and so does every caller of `cu_get_optimize_stmt`. `begin()` is the only place that treats a missing member as fatal.

`exmdb_optimize_stm=off` was no help either, which is what the reporter found. `begin_optim()` never looks at `g_exmdb_enable_optim_stm` — only the consumers do — so with the option off all seven statements are still prepared, can still fail the RPC, and nothing ever reads them.

Both of these predate 58f90c7ef; `begin_optim()` is unchanged since before that series. What 58f90c7ef added was the first statement that can fail against a healthy store, which is what made them reachable.


#323 