### PR TITLE
regression: fix deadlock between process() and notification_ctx::clear()

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,8 @@ Enhancements:
 
 Fixes:
 
+* mh_emsmdb: resolve a deadlock that made MAPI/HTTP clients (Outlook) hang on
+  every request
 * zcore no longer logs the ``session ... not found anymore`` message
 * zcore now scans mlist memberships when doing delegate permission checks
 * ruleproc no longer enters single-occurrence updates into user calendars.

--- a/exch/mh/emsmdb.cpp
+++ b/exch/mh/emsmdb.cpp
@@ -809,10 +809,7 @@ http_status MhEmsmdbPlugin::process(int context_id, const void *content,
 	ProcRes result;
 	auto heapctx = std::make_unique<MhEmsmdbContext>(context_id, m_server_version); /* huge object */
 	MhEmsmdbContext &ctx = *heapctx;
-	{
-		std::lock_guard ctx_hold(status[ctx.ID].lock);
-		status[ctx.ID].clear();
-	}
+	status[ctx.ID].clear();
 	if (ctx.auth_info.auth_status != http_status::ok)
 		return http_status::unauthorized;
 	if (!ctx.loadHeaders())


### PR DESCRIPTION
## Problem

Every MAPI/HTTP request deadlocks the worker thread that handles it, so Outlook clients cannot connect at all. Found in production after upgrading from `3.9.315.m310c04b` to `3.9.337.me85e712`; grommunio-web is unaffected, because `notification_ctx` exists only in `exch/mh/emsmdb.cpp` and webmail goes through zcore.

Two commits arrived at the same object's locking from opposite ends, three weeks apart, and neither is wrong on its own:

- `315d04795` (2026-07-20, *mh_emsmdb: take notification_ctx::lock in scanWork, term and process*) made `MhEmsmdbPlugin::process()` hold `notification_ctx::lock` across its call to `clear()`.
- `66fb675db` (2026-08-12, *exch: lock on notification context changes*, merged as `eaa985440` on 2026-08-19) made `clear()` acquire that same lock itself.

`notification_ctx::lock` is a plain `std::mutex` (`emsmdb.cpp:95`), so the second acquisition on the same thread is undefined behaviour and blocks on glibc. `process()` is wired up as `interface.proc = emsmdb_proc`, the MAPI/HTTP entry point, so the very first request from a client wedges its thread permanently and each further connection consumes another until the pool is exhausted.

## Change

Drop the outer `lock_guard` in `process()` and let `clear()` do the locking. The block existed solely to guard that one call, and `clear()` now locks its whole body, so the critical section is unchanged. This keeps `66fb675db`'s intent — `clear()` is safe on its own — rather than reverting it.

## Scope check

`clear()` is the only method on `notification_ctx` that locks internally, and `emsmdb.cpp:814` is its only call site. I read every other lock acquisition in the file: `scanWork()` takes `pending_lock` then `ctx->lock`, while `term()` and `async_wakeup()` take the ctx lock and release it before taking `pending_lock` in a separate scope. The ordering is consistently `pending_lock` then ctx lock and never nested the other way, so there is no second deadlock hiding behind this one.
