### PR TITLE
mapi: omit TZID when exporting DATE values in oxcical

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -301,7 +301,6 @@ AC_SUBST([my_CFLAGS])
 AC_SUBST([my_CXXFLAGS])
 AC_SUBST([my_LDFLAGS])
 
-AS_IF([test -z "$cxxmode"], [AC_MSG_RESULT([*** No usable -std= argument was detected for this C++ compiler.])])
 AC_LANG_POP([C++])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/exch/exmdb/message.cpp
+++ b/exch/exmdb/message.cpp
@@ -3488,6 +3488,7 @@ static ec_error_t opx_process(const rulexec_in &rp,
 		return ecError;
 	if (pvalue == nullptr)
 		return ecSuccess;
+	bv = static_cast<BINARY *>(pvalue);
 	ext_pull.init(bv->pb, bv->cb, common_util_alloc,
 		EXT_FLAG_WCOUNT | EXT_FLAG_UTF16);
 	EXT_RULE_ACTIONS ext_actions;

--- a/lib/mapi/oxcical.cpp
+++ b/lib/mapi/oxcical.cpp
@@ -3468,7 +3468,7 @@ static bool oxcical_export_exdate(const char *tzid, bool b_date,
 	auto &pivalue = piline->append_value();
 	if (b_date)
 		piline->append_param("VALUE", "DATE");
-	if (tzid != nullptr)
+	else if (tzid != nullptr)
 		piline->append_param("TZID", tzid);
 	for (size_t i = 0; i < apr->recur_pat.deletedinstancecount; ++i) {
 		b_found = false;
@@ -3529,7 +3529,7 @@ static bool oxcical_export_rdate(const char *tzid, bool b_date,
 	auto &pivalue = piline->append_value();
 	if (b_date)
 		piline->append_param("VALUE", "DATE");
-	if (tzid != nullptr)
+	else if (tzid != nullptr)
 		piline->append_param("TZID", tzid);
 	for (size_t i = 0; i < apr->recur_pat.modifiedinstancecount; ++i) {
 		b_found = false;
@@ -3661,7 +3661,7 @@ static void append_dt(ical_component &com, const char *key,
 	auto line = &com.append_line(key, txt);
 	if (b_date)
 		line->append_param("VALUE", "DATE");
-	if (tzid != nullptr)
+	else if (tzid != nullptr)
 		line->append_param("TZID", tzid);
 }
 

--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -603,6 +603,24 @@ static bool rx_eval_sub(const MESSAGE_CONTENT *ct, proptag_t tag,
 	}
 }
 
+/*
+ * String restrictions are charset-insensitive. A message stores PT_STRING8 or
+ * PT_UNICODE, while Outlook rules reference the PT_UNICODE tag. Fall back to
+ * the sibling string type when the exact tag is absent.
+ */
+static const void *rx_getval(const TPROPVAL_ARRAY &props, proptag_t tag)
+{
+	auto v = props.getval(tag);
+	if (v != nullptr)
+		return v;
+	auto t = PROP_TYPE(tag);
+	if (t == PT_UNICODE)
+		return props.getval(CHANGE_PROP_TYPE(tag, PT_STRING8));
+	if (t == PT_STRING8)
+		return props.getval(CHANGE_PROP_TYPE(tag, PT_UNICODE));
+	return nullptr;
+}
+
 static bool rx_eval_props(const MESSAGE_CONTENT *ct, const TPROPVAL_ARRAY &props,
     const RESTRICTION &res)
 {
@@ -621,14 +639,14 @@ static bool rx_eval_props(const MESSAGE_CONTENT *ct, const TPROPVAL_ARRAY &props
 		return !rx_eval_props(ct, props, res.xnot->res);
 	case RES_CONTENT: {
 		auto &rcon = *res.cont;
-		return rcon.comparable() && rcon.eval(props.getval(rcon.proptag));
+		return rcon.comparable() && rcon.eval(rx_getval(props, rcon.proptag));
 	}
 	case RES_PROPERTY: {
 		auto &rprop = *res.prop;
 		// XXX: special-case PR_ANR?
 		if (!rprop.comparable())
 			return false;
-		auto lhs = props.getval(rprop.proptag);
+		auto lhs = rx_getval(props, rprop.proptag);
 		if (rprop_srchkey_eq(rprop, lhs, rp_org_name.c_str(),
 		    mysql_adaptor_userid_to_name))
 			return rprop.relop == RELOP_EQ;

--- a/lib/ruleproc.cpp
+++ b/lib/ruleproc.cpp
@@ -1050,10 +1050,32 @@ static ec_error_t op_process(rxparam &par, const rule_node &rule)
 	return ecSuccess;
 }
 
+/* Extended-rule OP_MOVE/OP_COPY targets a folder in the user's own store. */
+static ec_error_t opx_move(rxparam &par, const rule_node &rule,
+    const EXT_MOVECOPY_ACTION &mc, uint8_t act_type)
+{
+	if (mc.folder_eid.eid_type != EITLT_PRIVATE_FOLDER)
+		return ecSuccess;
+	SVREID svreid;
+	svreid.folder_id = rop_util_make_eid_ex(1,
+		rop_util_gc_to_value(mc.folder_eid.folder_gc));
+	MOVECOPY_ACTION conv;
+	conv.same_store = 1;
+	conv.pfolder_eid = &svreid;
+	return op_copy(par, rule, conv, act_type);
+}
+
 static ec_error_t opx_switch(rxparam &par, const rule_node &rule,
     const EXT_ACTION_BLOCK &act, size_t act_idx)
 {
 	switch (act.type) {
+	case OP_MOVE:
+	case OP_COPY: {
+		auto mc = static_cast<EXT_MOVECOPY_ACTION *>(act.pdata);
+		if (mc == nullptr)
+			return ecSuccess;
+		return opx_move(par, rule, *mc, act.type);
+	}
 	case OP_MARK_AS_READ:
 		return op_read(par, rule);
 	case OP_TAG:


### PR DESCRIPTION
According to RFC 5545 section 3.2.19, the TZID parameter
must not be applied to DATE properties.

References: GXL-802 (#802)
