### PR TITLE
exch: small thread-safety improvement in emsmdb

### DIFF
--- a/exch/mh/emsmdb.cpp
+++ b/exch/mh/emsmdb.cpp
@@ -83,7 +83,7 @@ struct EMSMDB_HANDLE2 : public EMSMDB_HANDLE
 
 struct notification_ctx {
 	notification_ctx() = default;
-	notification_ctx(notification_ctx &&o) noexcept;
+	notification_ctx(notification_ctx &&o);
 	void clear();
 
 	uint8_t pending_status = PENDING_STATUS_NONE;
@@ -257,7 +257,7 @@ static constexpr struct cfg_directive mhems_gxcfg_deflt[] = {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Plugin structure definitions
 
-notification_ctx::notification_ctx(notification_ctx &&o) noexcept
+notification_ctx::notification_ctx(notification_ctx &&o)
 {
 	std::unique_lock lock_other(o.lock);
 	pending_status = std::move(o.pending_status);

--- a/exch/mh/emsmdb.cpp
+++ b/exch/mh/emsmdb.cpp
@@ -257,13 +257,15 @@ static constexpr struct cfg_directive mhems_gxcfg_deflt[] = {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Plugin structure definitions
 
-notification_ctx::notification_ctx(notification_ctx &&o) noexcept :
-	pending_status(std::move(o.pending_status)),
-	notification_status(std::move(o.notification_status)),
-	session_guid(std::move(o.session_guid)),
-	pending_time(std::move(o.pending_time)),
-	wall_start_time(std::move(o.wall_start_time))
-{}
+notification_ctx::notification_ctx(notification_ctx &&o) noexcept
+{
+	std::unique_lock lock_other(o.lock);
+	pending_status = std::move(o.pending_status);
+	notification_status = std::move(o.notification_status);
+	session_guid = std::move(o.session_guid);
+	pending_time = std::move(o.pending_time);
+	wall_start_time = std::move(o.wall_start_time);
+}
 
 void notification_ctx::clear()
 {


### PR DESCRIPTION
Move-constructor for notification_ctx is made thread-safe.
Fixing coverity issues 1685359, 1685358, 1685357, 1663976, 1663972.
