### PR TITLE
oxcical: accept recurring iCal with more EXDATEs than RDATEs

### DIFF
--- a/lib/mapi/oxcical.cpp
+++ b/lib/mapi/oxcical.cpp
@@ -2472,8 +2472,15 @@ static ec_error_t oxcical_import_internal(const char *method,
 				errstr = "E-2720";
 				return ecInvalidParam;
 			}
-			if (apr.recur_pat.modifiedinstancecount < apr.recur_pat.deletedinstancecount) {
-				errstr = "E-2721: ical object did not meet condition recur_pat.modifiedinstancecount < recur_pat.deletedinstancecount";
+			/*
+			 * MS-OXOCAL v21 §2.2.1.44.1: ModifiedInstanceCount
+			 * must not exceed DeletedInstanceCount; surplus
+			 * EXDATEs stay plain deletions, and the pairing below
+			 * would otherwise read deleted_dates beyond what
+			 * EXDATE supplied.
+			 */
+			if (apr.recur_pat.modifiedinstancecount > apr.recur_pat.deletedinstancecount) {
+				errstr = "E-2721: ical object has more RDATE than EXDATE values";
 				return ecInvalidParam;
 			}
 			apr.exceptioncount = apr.recur_pat.modifiedinstancecount;


### PR DESCRIPTION
A recurring meeting invitation whose iCalendar object cancels more occurrences than it moves is rejected on import, and the whole calendar object is dropped into the message as a `.vcs` attachment instead. The recipient gets a plain `IPM.Note` with a file attached rather than a meeting request, so no client offers Accept or Decline and the appointment never reaches the calendar. On the affected server this fires several times a week and accounts for every `W-2728` in a month of `gromox-delivery` logs.

## Mechanism

`oxcical_parse_recurrence()` maps iCalendar `EXDATE` onto `DeletedInstanceCount` and `RDATE` onto `ModifiedInstanceCount`, then pairs them positionally, taking `deleted_dates[i]` as the original start date of the exception at `modified_dates[i]`:

```c
apr.exceptioncount = apr.recur_pat.modifiedinstancecount;
for (size_t i = 0; i < apr.exceptioncount; ++i) {
        ext_exceptions[i].startdatetime = exceptions[i].startdatetime = modified_dates[i];
        ext_exceptions[i].originalstartdate = exceptions[i].originalstartdate = deleted_dates[i];
```

The guard in front of that loop rejects the wrong side of the relation:

```c
if (apr.recur_pat.modifiedinstancecount < apr.recur_pat.deletedinstancecount) {
        errstr = "E-2721: ...";
        return ecInvalidParam;
```

MS-OXOCAL v21 §2.2.1.44.1 requires `ModifiedInstanceCount` to be **less than or equal to** `DeletedInstanceCount`, so the two conditions only overlap when the counts are equal. Everything else is refused, including the ordinary case of a series with three cancelled occurrences and one moved one. The direction that is actually unsafe is the opposite one: when `RDATE` supplies more dates than `EXDATE`, the loop indexes `deleted_dates` past the entries `oxcical_parse_dates()` filled in and pairs the exception with an uninitialised original start date.

Inverting the comparison lets the compliant case through — the surplus `EXDATE` values stay plain deletions, which is what `DeletedInstanceCount` already means — and keeps the loop within the dates that were parsed.

## Testing

Built from this branch and run against `gromox-eml2mt --mail`, with a recurring `METHOD:REQUEST` carrying `EXDATE` with three dates and one `RDATE`:

| | message class | attachment |
|---|---|---|
| 3.9.228 as shipped | `IPM.Note` | `attachment1.vcs` |
| this branch | `IPM.Schedule.Meeting.Request` | none |

The inverse object, one `EXDATE` and three `RDATE` values, still returns `ecInvalidParam` on this branch, now with a message that names what was wrong.

## Notes

The positional pairing of `RDATE` to `EXDATE` is pre-existing behaviour and is left alone here; RFC 5545 treats the two properties as independent, so which exclusion belongs to which added date is a guess whenever there is more than one. That is worth revisiting separately, but it only decides which occurrence an exception is attached to, whereas today the entire invitation is discarded.