### PR TITLE
lda: separate the autoreply subject prefix from the subject

### DIFF
--- a/doc/gromox.cfg.5
+++ b/doc/gromox.cfg.5
@@ -27,7 +27,8 @@ Out-of-office replies use the subject that was set alongside the OOF message.
 Clients which configure OOF over EWS cannot set one, because
 SetUserOofSettings has no field for it. When no subject is stored, this prefix
 plus the subject of the incoming message is used instead. Set to the empty
-string to send such replies without a subject.
+string to send such replies without a subject. A prefix not ending in
+whitespace is separated from that subject by a space.
 .br
 Default: \fIOut of Office: \fP
 .TP

--- a/mda/exmdb_local/exmdb_local.cpp
+++ b/mda/exmdb_local/exmdb_local.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <vector>
 #include <fmt/core.h>
+#include <libHX/ctype_helper.h>
 #include <libHX/string.h>
 #include <sys/stat.h>
 #include <gromox/bounce_gen.hpp>
@@ -522,7 +523,7 @@ void exmdb_local_log_info(const CONTROL_INFO &ctrl,
 
 static constexpr cfg_directive mdlgx_cfg_defaults[] = {
 	{"autoreply_silence_window", "1day", CFG_TIME, "0"},
-	{"autoreply_subject_prefix", "Out of office: "},
+	{"autoreply_subject_prefix", "Out of Office: "},
 	CFG_TABLE_END,
 };
 
@@ -546,6 +547,14 @@ bool HOOK_exmdb_local(enum plugin_op reason, const struct dlfuncs &ppdata)
 		if (cfg != nullptr) {
 			autoreply_silence_window = cfg->get_ll("autoreply_silence_window");
 			autoreply_subject_prefix = znul(cfg->get_value("autoreply_subject_prefix"));
+			/*
+			 * The prefix carries its own separator, and config_file_init
+			 * trims trailing whitespace off every line, so a configured
+			 * one cannot express it.
+			 */
+			if (!autoreply_subject_prefix.empty() &&
+			    !HX_isspace(autoreply_subject_prefix.back()))
+				autoreply_subject_prefix += ' ';
 			g_junk_rules = parse_junk_rules(cfg->get_value("lda_junk_rules"));
 		}
 


### PR DESCRIPTION
autoreply_subject_prefix is concatenated with the subject of the incoming message, so the prefix has to carry the separating space itself. The compiled-in default does, but config_file_init trims trailing whitespace off every configuration line, so an administrator cannot write one. A prefix set in gromox.cfg therefore produced

	Subject: Out of Office:Re: Vertrag

Append a space to a configured prefix that does not end in whitespace. The default is unaffected, and the branch that drops the separator when there is no incoming subject still finds it.

The default itself said "Out of office" where the manual page, the rest of the documentation and grommunio-web all say "Out of Office". Spell it the same way, so a mailbox left on the default and one whose subject grommunio-web filled in agree.