### PR TITLE
ews: flush the parent message instance after CreateAttachment

### DIFF
--- a/exch/ews/exceptions.hpp
+++ b/exch/ews/exceptions.hpp
@@ -603,6 +603,7 @@ E(3471, "failed to delete cancelled meeting");
 E(3472, "cannot read from item's source folder");
 E(3473, "cannot write to destination folder");
 E(3474, "access denied: missing Send-As permission on the claimed sender identity");
+E(3475, "failed to persist attachment to parent message");
 
 #undef E
 }

--- a/exch/ews/requests.cpp
+++ b/exch/ews/requests.cpp
@@ -1200,6 +1200,25 @@ void process(mCreateAttachmentRequest &&request, XMLElement *response,
 			if (!ctx.plugin().exmdb.flush_instance(dir.c_str(),
 			    aInstId, &err) || err != ecSuccess)
 				throw EWSError::ItemSave(E3431);
+			/*
+			 * Flushing an attachment instance only merges it into its
+			 * parent message instance's in-memory content
+			 * (exmdb_server::flush_instance()'s instance_type::attachment
+			 * branch, exch/exmdb/instance.cpp) - it does not touch the
+			 * database. The message instance itself must be flushed too
+			 * for the attachment to actually reach the attachments/
+			 * attachment_properties tables; without this, CreateAttachment
+			 * reports success (the attachment is genuinely present in the
+			 * cached message instance at that point) but the attachment
+			 * silently never persists - observed live: present right
+			 * after CreateAttachment, gone from the store (and thus from
+			 * the sent mail) by the time the message is read back via
+			 * read_message()/movecopy_message() at send time. Mirrors
+			 * what DeleteAttachment already does correctly below.
+			 */
+			if (!ctx.plugin().exmdb.flush_instance(dir.c_str(),
+			    mInst->instanceId, &err) || err != ecSuccess)
+				throw EWSError::ItemSave(E3475);
 
 			sShape shape;
 			ctx.updated(dir, mid, shape);


### PR DESCRIPTION
Attachments added via `CreateAttachment` were silently lost by the time the message was sent: reproduced live (Outlook for Mac, compose -> attach a file -> send), confirmed both in the delivered mail and in the Sent Items copy - and directly in `exchange.sqlite3`, where the freshly sent message had zero rows in `attachments` despite `CreateAttachment` having reported `ResponseClass="Success"` moments earlier.

Root cause: `CreateAttachment`'s handler flushes only the newly-created *attachment* instance (`flush_instance(aInstId)`), never the *parent message* instance (`mInst->instanceId`) it belongs to. Per `exmdb_server::flush_instance()`'s `instance_type::attachment` branch (`exch/exmdb/instance.cpp`), flushing an attachment instance only merges it into its parent message instance's in-memory `MESSAGE_CONTENT` - it never touches the database. The attachment only becomes durable once the *message* instance itself is flushed, and nothing in `CreateAttachment`'s handler ever did that. `DeleteAttachment`, right below it in the same file, gets this right: it flushes `mInst->instanceId` after modifying the message instance's attachments.

Fix: flush the parent message instance too, mirroring `DeleteAttachment`.

Verified live (Outlook for Mac): attachment now present in `attachments`/`attachment_properties` for the sent message, and the delivered mail (checked via the SMTP relay log) carries the expected size increase for the attached file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)