### PR TITLE
mapi: strip the NUL terminator from third-party UIDs in GlobalObjectId

### DIFF
--- a/exch/ews/structures.cpp
+++ b/exch/ews/structures.cpp
@@ -49,10 +49,11 @@ std::string goid_to_uid(const BINARY &goid_bin)
 	EXT_PULL ep;
 	ep.init(goid_bin.pb, goid_bin.cb,
 	    EWSContext::alloc, 0);
-	if (ep.g_goid(&goid) == pack_result::ok &&
-	    goid.data.cb > 12 &&
-	    memcmp(goid.data.pb, ThirdPartyGlobalId, 12) == 0)
-		return std::string(&goid.data.pc[12], goid.data.cb - 12);
+	if (ep.g_goid(&goid) == pack_result::ok) {
+		auto tp_uid = goid.third_party_uid();
+		if (!tp_uid.empty())
+			return tp_uid;
+	}
 	return bin2hex(goid_bin.pc, goid_bin.cb);
 }
 

--- a/include/gromox/mapi_types.hpp
+++ b/include/gromox/mapi_types.hpp
@@ -609,6 +609,8 @@ struct GX_EXPORT GLOBALOBJECTID {
 	uint8_t x[8]{};
 	BINARY data{};
 	bool unparsed = false;
+
+	std::string third_party_uid() const;
 };
 
 struct GX_EXPORT EID_ARRAY {

--- a/lib/freebusy.cpp
+++ b/lib/freebusy.cpp
@@ -312,12 +312,11 @@ static int goid_to_icaluid2(const BINARY *gobj, std::string &uid_buf) try
 	ext_pull.init(gobj->pb, gobj->cb, malloc, 0);
 	if (ext_pull.g_goid(&ngid) != pack_result::ok)
 		return -EIO;
-	static_assert(sizeof(ThirdPartyGlobalId) == 12);
-	if (ngid.data.cb >= 12 && memcmp(ngid.data.pc, ThirdPartyGlobalId, 12) == 0) {
-		auto m = ngid.data.cb - 12;
-		if (m > 255)
-			m = 255;//check if this is the typical boundary(OXFB)
-		uid_buf.assign(&ngid.data.pc[12], m);
+	auto tp_uid = ngid.third_party_uid();
+	if (!tp_uid.empty()) {
+		if (tp_uid.size() > 255)
+			tp_uid.resize(255);//check if this is the typical boundary(OXFB)
+		uid_buf = std::move(tp_uid);
 		return 1;
 	}
 

--- a/lib/mapi/ext_buffer2.cpp
+++ b/lib/mapi/ext_buffer2.cpp
@@ -423,3 +423,15 @@ pack_result EXT_PUSH::p_eid_a(std::span<const eid_t> r, uint8_t ix)
 		TRY(p_uint64(eid.m_value));
 	return pack_result::ok;
 }
+
+std::string GLOBALOBJECTID::third_party_uid() const
+{
+	static_assert(sizeof(ThirdPartyGlobalId) == 12);
+	if (data.pb == nullptr || data.cb <= 12 ||
+	    memcmp(data.pb, ThirdPartyGlobalId, 12) != 0)
+		return {};
+	size_t len = data.cb - 12;
+	while (len > 0 && data.pc[12+len-1] == '\0')
+		--len;
+	return std::string(&data.pc[12], len);
+}

--- a/lib/mapi/oxcical.cpp
+++ b/lib/mapi/oxcical.cpp
@@ -3631,9 +3631,9 @@ static const char *oxcical_export_uid(const MESSAGE_CONTENT &msg,
 	ext_pull.init(bin->pb, bin->cb, alloc, 0);
 	if (ext_pull.g_goid(&goid) != pack_result::ok)
 		return oxcical_export_uidx(com);
-	if (goid.data.pb != nullptr && goid.data.cb >= 12 &&
-	    memcmp(goid.data.pb, ThirdPartyGlobalId, 12) == 0) {
-		com.append_line("UID", std::string(&goid.data.pc[12], goid.data.cb - 12));
+	auto tp_uid = goid.third_party_uid();
+	if (!tp_uid.empty()) {
+		com.append_line("UID", std::move(tp_uid));
 		return nullptr;
 	}
 

--- a/tests/utiltest.cpp
+++ b/tests/utiltest.cpp
@@ -82,6 +82,31 @@ static int t_extpp()
 	ep.init(s.data(), s.size(), zalloc, 0);
 	assert(ep.g_goid(&goid) == pack_result::ok);
 	assert(goid.unparsed && goid.data.cb == 5);
+
+	/*
+	 * "vCal-Uid", 0x01000000, the UID and a NUL that Size counts: what
+	 * Outlook and every spec-conformant client writes when wrapping a UID
+	 * that did not originate in MAPI. Handing the terminator out puts a NUL
+	 * inside an ical UID line and the payload stops parsing.
+	 */
+#define s_vcal "7643616c2d55696401000000"
+#define s_uid "63653634633666352d653964362d346363392d383538382d613266623536326165346565"
+	s = encid + hex2bin(s_date "31000000" s_vcal s_uid "00");
+	ep.init(s.data(), s.size(), zalloc, 0);
+	assert(ep.g_goid(&goid) == pack_result::ok);
+	assert(goid.third_party_uid() == "ce64c6f5-e9d6-4cc9-8588-a2fb562ae4ee");
+	/* Gromox itself omits the terminator, so both spellings must decode. */
+	s = encid + hex2bin(s_date "30000000" s_vcal s_uid);
+	ep.init(s.data(), s.size(), zalloc, 0);
+	assert(ep.g_goid(&goid) == pack_result::ok);
+	assert(goid.third_party_uid() == "ce64c6f5-e9d6-4cc9-8588-a2fb562ae4ee");
+	/* Without the marker the caller must fall back to the hex-encoded blob. */
+	s = encid + hex2bin(s_date "04000000deadbeef");
+	ep.init(s.data(), s.size(), zalloc, 0);
+	assert(ep.g_goid(&goid) == pack_result::ok);
+	assert(goid.third_party_uid().empty());
+#undef s_uid
+#undef s_vcal
 #undef s_date
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
gromox writes an iCalendar UID line with a NUL byte inside it, and then refuses to read that line back. Measured on prime 0980fd5a5, one message whose `PidLidGlobalObjectId` was minted by a CalDAV client, exported and then re-parsed:

| | export | re-parse of the export |
|---|---|---|
| before | `UID:ce64c6f5-…-a2fb562ae4ee<00>`, 363 bytes | refused |
| after | `UID:ce64c6f5-…-a2fb562ae4ee`, 362 bytes | accepted, and re-imports into MAPI |

## Mechanism

A UID that did not originate in MAPI travels inside `PidLidGlobalObjectId` as the `ThirdPartyGlobalId` marker, the string, and a terminating NUL that the Size field counts (MS-OXOCAL v21 §2.2.1.27; MS-ASEMAIL §2.2.2.37 spells the decoding out as "minus one byte for null-terminating 00 byte").

Three readers take `data.cb - 12` bytes verbatim and hand the terminator to their callers:

```c
com.append_line("UID", std::string(&goid.data.pc[12], goid.data.cb - 12)); // oxcical.cpp:3636
return std::string(&goid.data.pc[12], goid.data.cb - 12);                  // ews/structures.cpp:55
auto m = ngid.data.cb - 12;                                                // freebusy.cpp:317
```

For iCalendar that is a UID line with a NUL in it: `mapi_to_ical()` emits it, `ical::load_from_str_move()` refuses it. A CalDAV client that reads such an event, edits it and PUTs it back is stuck — the server rejects what the server just produced. EWS and free/busy put the same byte into their own output.

## Change

One accessor on `GLOBALOBJECTID` that trims the terminator, used in all three places. Gromox's own writers leave the terminator off (`data.cb = 12 + tmp_len`), so the length is trimmed rather than reduced by one, and both spellings decode alike. A blob without the marker yields an empty string, which is what the callers already use to fall back to the hex-encoded whole blob.

## Test

`tests/utiltest` gains three cases in `t_extpp`: the terminated form, the unterminated form gromox writes itself, and a blob without the marker. No new test program and no build-system change. `make check` passes 3/3.

## Found

Two recurring series created by a CalDAV client on a production store could not be re-imported from their own export.
