### PR TITLE
zcore: build user EntryIDs from the whole address

### DIFF
--- a/exch/zcore/common_util.cpp
+++ b/exch/zcore/common_util.cpp
@@ -460,20 +460,13 @@ static BOOL common_util_username_to_entryid(const char *username,
     const char *pdisplay_name, BINARY *pbin, enum display_type *dtpp)
 {
 	unsigned int user_id = 0, domain_id = 0;
-	char *pdomain;
 	EXT_PUSH ext_push;
-	char tmp_name[UADDR_SIZE];
 	ONEOFF_ENTRYID oneoff_entry;
 	enum display_type dtypx = DT_MAILUSER;
 	
 	if (mysql_adaptor_get_user_ids(username, &user_id, &domain_id, &dtypx)) {
-		gx_strlcpy(tmp_name, username, std::size(tmp_name));
-		pdomain = strchr(tmp_name, '@');
-		if (pdomain == nullptr)
-			return FALSE;
-		*pdomain = '\0';
 		std::string essdn;
-		if (cvt_username_to_essdn(tmp_name, g_org_name, user_id,
+		if (cvt_username_to_essdn(username, g_org_name, user_id,
 		    domain_id, essdn) != ecSuccess)
 			return false;
 		if (!common_util_essdn_to_entryid(essdn.c_str(), pbin,

--- a/tests/utiltest.cpp
+++ b/tests/utiltest.cpp
@@ -21,6 +21,7 @@
 #include <gromox/propval.hpp>
 #include <gromox/resource_pool.hpp>
 #include <gromox/rop_util.hpp>
+#include <gromox/usercvt.hpp>
 #include <gromox/util.hpp>
 #undef assert
 #define assert(x) do { if (!(x)) { printf("%s failed\n", #x); return EXIT_FAILURE; } } while (false)
@@ -683,6 +684,32 @@ static int t_tzdef()
 	return EXIT_SUCCESS;
 }
 
+static ec_error_t essdn_id2user(unsigned int, std::string &out)
+{
+	out = "sender@example.org";
+	return ecSuccess;
+}
+
+static int t_essdn()
+{
+	/*
+	 * cvt_username_to_essdn splits the address itself, so a caller hands
+	 * over the whole thing. A bare local part selects the public-store
+	 * branch instead, and the ESSDN then names no mailbox at all.
+	 */
+	std::string essdn, back;
+	assert(cvt_username_to_essdn("sender@example.org", "example",
+	       0x11, 0x22, essdn) == ecSuccess);
+	assert(essdn.find("-sender") != essdn.npos);
+	assert(cvt_essdn_to_username(essdn.c_str(), "example",
+	       essdn_id2user, back) == ecSuccess);
+	assert(back == "sender@example.org");
+	assert(cvt_username_to_essdn("sender", "example",
+	       0x11, 0x22, essdn) == ecSuccess);
+	assert(essdn.find("-public.folder.root") != essdn.npos);
+	return EXIT_SUCCESS;
+}
+
 static int runner()
 {
 	if (t_cookie_jar() != 0)
@@ -700,7 +727,7 @@ static int runner()
 		t_id7, t_id8, t_id9, t_seq,
 		t_cmp_binary, t_cmp_guid, t_cmp_svreid, t_cmp_icaltime,
 		t_wildcard, t_utf8_prefix, t_eidcvt, t_bin2cstr, t_string,
-		t_time, t_tzdef,
+		t_time, t_tzdef, t_essdn,
 	};
 	for (auto f : fct) {
 		auto ret = f();


### PR DESCRIPTION
zcore mints ESSDN EntryIDs that gromox itself cannot resolve back. Measured with `cvt_username_to_essdn()` followed by `cvt_essdn_to_username()`:

| input | ESSDN | resolves back to |
|---|---|---|
| `sender@example.org` | `.../cn=2200000011000000-sender` | `sender@example.org` |
| `sender` -- what the caller passes | `.../cn=2200000011000000-public.folder.root` | `ecUnknownUser` |

## Mechanism

`common_util_username_to_entryid()` cuts the domain off first, but `cvt_username_to_essdn()` splits the address itself, and a name with no `@` selects the public-store branch da7de4ce7 added. The numeric half of the cn still names the right user, so nothing fails where the EntryID is written; `cvt_essdn_to_username()` is the reader that checks the textual half, and it answers `ecUnknownUser`.

This is the `username_to_entryid` callback zcore installs for iCalendar import (`cu_ical_to_message`, `cu_ical_to_message2`), so it covers the organizer (`PR_SENT_REPRESENTING_ENTRYID`, `PR_SENDER_ENTRYID`) and every attendee of an appointment created over CalDAV or from the web client.

## Where it comes from

`common_util_username_to_entryid()` composed the ESSDN itself with a single `snprintf()` until 14aacee45 replaced that with a call to the shared helper and kept the caller's split in place. da7de4ce7 had landed twelve days earlier, so the public-store branch was already there to absorb the bare name; before it the helper answered `ecInvalidParam`, and the same mistake would have failed loudly. The two other call sites in this file pass the helper a whole address.

## Change

Hand `username` to the helper instead of `tmp_name`. This also drops the early `return FALSE` for a name with no `@` in it: the helper handles that shape deliberately, and `mysql_adaptor_get_user_ids()` has already accepted the name.

## Test

`tests/utiltest` gains the round trip for a full address and the public-store branch for a bare name, so the requirement on the caller is written down somewhere. `make check` passes 3/3.
