### PR TITLE
zcore: mark an embedded message dirty when its properties change

### DIFF
--- a/exch/zcore/message_object.cpp
+++ b/exch/zcore/message_object.cpp
@@ -829,8 +829,11 @@ static ec_error_t message_object_set_properties_internal(message_object *pmessag
 		tmp_problems.transform(poriginal_indices);
 		problems += std::move(tmp_problems);
 	}
-	if (pmessage->b_new || pmessage->message_id == 0)
+	if (pmessage->b_new || pmessage->message_id == 0) {
+		/* save() flushes nothing otherwise; emsmdb marks it here too */
+		pmessage->b_touched = TRUE;
 		return ecSuccess;
+	}
 
 	for (unsigned int i = 0; i < ppropvals->count; ++i) {
 		if (problems.have_index(i))
@@ -890,8 +893,11 @@ ec_error_t message_object::remove_properties(proptag_cspan pproptags) try
 		tmp_problems.transform(poriginal_indices);
 		problems += std::move(tmp_problems);
 	}
-	if (pmessage->b_new || pmessage->message_id == 0)
+	if (pmessage->b_new || pmessage->message_id == 0) {
+		/* as in set_properties */
+		pmessage->b_touched = TRUE;
 		return ecSuccess;
+	}
 
 	for (unsigned int i = 0; i < pproptags.size(); ++i) {
 		if (problems.have_index(i))


### PR DESCRIPTION
`message_object::save()` in exch/zcore flushes nothing unless `b_touched` is set:

```c
if (!pmessage->b_new && !pmessage->b_touched)
        return ecSuccess;
```

and neither `set_properties` nor `remove_properties` sets it for an embedded message, because the guard that skips the change bookkeeping returns first:

```c
/* exch/zcore/message_object.cpp */
if (pmessage->b_new || pmessage->message_id == 0)
        return ecSuccess;
```

The same guard in exch/emsmdb marks the object:

```c
/* exch/emsmdb/message_object.cpp */
if (pmessage->b_new || pmessage->message_id == 0) {
        pmessage->b_touched = TRUE;
        return ecSuccess;
}
```

An embedded message always has `message_id == 0` -- that is how `zs_openembedded` constructs it -- so every in-place property change to one is written into the instance and then dropped when the handle goes away. `set_instance_properties` has already succeeded, so a read through the same handle shows the new value, and both setprops and savechanges return `ecSuccess`. Nothing reports a failure; the write is simply not there on the next open.

What this costs is the ability to edit a recurrence exception in place. An exception lives as an embedded message under an attachment of the series, so correcting one property of one occurrence -- a `PidLidExceptionReplaceTime` left disagreeing with the recurrence blob, say -- is not expressible through this interface at all. The way around it is to rewrite the whole series, which loses every property an iCalendar round trip does not carry.

New messages escape this because `b_new` drives `save()` by itself, which is why creating exceptions on import works and only later edits vanish. `copy_to` does not set the flag in either implementation and is left alone.

No automated test: the tests in this tree are library-level, and zcore needs a store and a session. Reproducible through php_mapi -- open an appointment that has exceptions, walk to the embedded message through its attachment, set one property, save both objects, reopen: the old value is back.
