### PR TITLE
oxcical: warn when an imported time carries no zone

### DIFF
--- a/exch/zcore/common_util.cpp
+++ b/exch/zcore/common_util.cpp
@@ -1802,6 +1802,7 @@ message_ptr cu_ical_to_message(store_object *pstore, const BINARY *pical_bin) tr
 	common_util_set_dir(pstore->get_dir());
 
 	oxcical_converter cvt;
+	cvt.log_id = pstore->get_dir();
 	cvt.alloc = common_util_alloc;
 	cvt.get_propids = common_util_get_propids_create;
 	cvt.username_to_entryid = common_util_username_to_entryid;
@@ -1821,13 +1822,14 @@ ec_error_t cu_ical_to_message2(store_object *store, char *ical_data,
 
 	std::string errstr;
 	oxcical_converter cvt;
+	cvt.log_id = store->get_dir();
 	cvt.alloc = common_util_alloc;
 	cvt.get_propids = common_util_get_propids_create;
 	cvt.username_to_entryid = common_util_username_to_entryid;
 	auto err = cvt.ical_to_mapi_multi(icobj, msgvec, errstr);
 	if (err != ecSuccess)
-		mlog(LV_ERR, "ical_to_mapi_multi: %s", errstr.size() > 0 ?
-			errstr.c_str() : mapi_strerror(err));
+		mlog(LV_ERR, "ical_to_mapi_multi %s: %s", store->get_dir(),
+			errstr.size() > 0 ? errstr.c_str() : mapi_strerror(err));
 	return err;
 } catch (const std::bad_alloc &) {
 	mlog(LV_ERR, "%s: ENOMEM", __func__);

--- a/lib/mapi/oxcical.cpp
+++ b/lib/mapi/oxcical.cpp
@@ -2910,6 +2910,49 @@ static uint32_t oxcical_get_calendartype(const ical_line *piline)
 	return it != std::end(cal_scale_names) ? it->first : CAL_DEFAULT;
 }
 
+/*
+ * First timed property with neither TZID nor Z, i.e. floating time (RFC 5545
+ * §3.3.5 form #1). VALUE=DATE is not reported; a date has no zone to name.
+ */
+static const ical_line *oxcical_first_floating_dt(const ical_component &comp)
+{
+	static constexpr const char *timed[] = {"DTSTART", "DTEND", "RECURRENCE-ID"};
+	for (auto name : timed) {
+		auto line = comp.get_line(name);
+		if (line == nullptr)
+			continue;
+		auto vtype = line->get_first_paramval("VALUE");
+		if (vtype != nullptr && strcasecmp(vtype, "DATE-TIME") != 0)
+			continue;
+		if (line->get_first_paramval("TZID") != nullptr)
+			continue;
+		auto value = line->get_first_subvalue();
+		if (value == nullptr || *value == '\0')
+			continue;
+		auto len = strlen(value);
+		if (value[len-1] != 'Z' && value[len-1] != 'z')
+			return line;
+	}
+	return nullptr;
+}
+
+/* The reading is not recoverable afterwards, so say so as it happens */
+static void oxcical_note_floating_times(const uidxevent_list_t &uid_list,
+    const char *log_id)
+{
+	for (const auto &[uid, events] : uid_list)
+		for (const auto *comp : events) {
+			auto line = oxcical_first_floating_dt(*comp);
+			if (line == nullptr)
+				continue;
+			mlog(LV_WARN, "W-2746: %s: %s \"%s\" (UID \"%s\") names no time "
+				"zone; it is read as UTC, which shifts the appointment by "
+				"the author's offset", log_id, line->m_name.c_str(),
+				line->get_first_subvalue(), uid.c_str());
+			break;
+		}
+}
+
 /**
  * Read a bunch of VCALENDAR/VEVENT items from @pical and put each of them as
  * messages into @finalvec.
@@ -2931,6 +2974,7 @@ ec_error_t oxcical_converter::ical_to_mapi_multi(const ical &pical,
 		errstr = "E-2412: iCal data contained no VEVENTs with UIDs";
 		return ecInvalidParam;
 	}
+	oxcical_note_floating_times(uid_list, log_id);
 	auto first_comp = uid_list.begin()->second.front();
 	if (strcasecmp(first_comp->m_name.c_str(), "VTODO") == 0) {
 		message_ptr msg(message_content_init());

--- a/lib/mapi/oxcmail.cpp
+++ b/lib/mapi/oxcmail.cpp
@@ -2634,6 +2634,7 @@ std::unique_ptr<message_content, mc_delete> oxcmail_converter::inet_to_mapi(cons
 				mime_enum.pcalendar = nullptr;
 			} else {
 				oxcical_converter ical_cvt;
+				ical_cvt.log_id = log_id;
 				ical_cvt.alloc = alloc;
 				ical_cvt.get_propids = get_propids;
 				ical_cvt.username_to_entryid = oxcmail_username_to_entryid;

--- a/tests/utiltest.cpp
+++ b/tests/utiltest.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <limits>
+#include <unistd.h>
 #include <libHX/endian.h>
 #include <libHX/string.h>
 #include <gromox/cookie_parser.hpp>
@@ -17,11 +18,13 @@
 #include <gromox/idset.hpp>
 #include <gromox/mail_func.hpp>
 #include <gromox/mapi_types.hpp>
+#include <gromox/oxcmail.hpp>
 #include <gromox/paths.h>
 #include <gromox/propval.hpp>
 #include <gromox/resource_pool.hpp>
 #include <gromox/rop_util.hpp>
 #include <gromox/util.hpp>
+#include "../tools/staticnpmap.cpp"
 #undef assert
 #define assert(x) do { if (!(x)) { printf("%s failed\n", #x); return EXIT_FAILURE; } } while (false)
 using namespace gromox;
@@ -683,6 +686,71 @@ static int t_tzdef()
 	return EXIT_SUCCESS;
 }
 
+static alloc_context t_alloc_mgr;
+static void *t_alloc(size_t z) { return t_alloc_mgr.alloc(z); }
+
+/*
+ * A DTSTART with neither a TZID parameter nor a Z designator is floating time
+ * (RFC 5545 §3.3.5 form #1). It is read by declaring the wall clock to be UTC,
+ * which is what Exchange does; the reading is pinned here rather than changed.
+ * What it must not do is happen quietly: nothing in the resulting object
+ * records the hour that was meant, so W-2746 is the only thing that can
+ * attribute the shift afterwards.
+ */
+static int t_floating_dt()
+{
+	char input[] =
+		"BEGIN:VCALENDAR\r\n"
+		"VERSION:2.0\r\n"
+		"PRODID:-//Gromox//utiltest//EN\r\n"
+		"BEGIN:VEVENT\r\n"
+		"UID:floating-no-zone\r\n"
+		"DTSTAMP:20260909T120000Z\r\n"
+		"SUMMARY:floating DTSTART\r\n"
+		"DTSTART:20260811T103000\r\n"
+		"DTEND:20260811T110000\r\n"
+		"END:VEVENT\r\n"
+		"END:VCALENDAR\r\n";
+	ical ic;
+	assert(ic.load_from_str_move(input));
+
+	char logfile[] = "/tmp/gromox-utiltest-XXXXXX";
+	auto fd = mkstemp(logfile);
+	assert(fd >= 0);
+	close(fd);
+	mlog_init(nullptr, logfile, LV_WARN);
+	oxcical_converter cvt;
+	cvt.alloc = t_alloc;
+	cvt.get_propids = ee_get_propids;
+	cvt.log_id = "u@d.at";
+	std::vector<std::unique_ptr<message_content, mc_delete>> vec;
+	std::string errstr;
+	auto err = cvt.ical_to_mapi_multi(ic, vec, errstr);
+	mlog_init(nullptr, "-", LV_NOTICE);
+
+	std::string log;
+	auto fp = fopen(logfile, "r");
+	if (fp != nullptr) {
+		char buf[512];
+		size_t rd;
+		while ((rd = fread(buf, 1, sizeof(buf), fp)) > 0)
+			log.append(buf, rd);
+		fclose(fp);
+	}
+	unlink(logfile);
+
+	assert(err == ecSuccess);
+	assert(vec.size() == 1);
+	auto start = vec[0]->proplist.get<const uint64_t>(PR_START_DATE);
+	assert(start != nullptr);
+	/* 2026-08-11T10:30:00Z, i.e. the reading taken verbatim as UTC */
+	assert(rop_util_nttime_to_unix(*start) == 1786444200);
+	assert(log.find("W-2746") != std::string::npos);
+	assert(log.find("u@d.at") != std::string::npos);
+	assert(log.find("20260811T103000") != std::string::npos);
+	return EXIT_SUCCESS;
+}
+
 static int runner()
 {
 	if (t_cookie_jar() != 0)
@@ -700,7 +768,7 @@ static int runner()
 		t_id7, t_id8, t_id9, t_seq,
 		t_cmp_binary, t_cmp_guid, t_cmp_svreid, t_cmp_icaltime,
 		t_wildcard, t_utf8_prefix, t_eidcvt, t_bin2cstr, t_string,
-		t_time, t_tzdef,
+		t_time, t_tzdef, t_floating_dt,
 	};
 	for (auto f : fct) {
 		auto ret = f();


### PR DESCRIPTION
An iCalendar time that carries no zone is read as UTC, and nothing anywhere records that it happened. Measured on a27b6be94, one VEVENT with `DTSTART:20260811T103000` and no `TZID`:

| | stored instant | log |
|---|---|---|
| before | 10:30Z | silent |
| after | 10:30Z | `W-2746: /var/lib/gromox/user/d.at/u: DTSTART "20260811T103000" (UID "floating-no-zone") names no time zone; it is read as UTC, which shifts the appointment by the author's offset` |

The reading itself is unchanged.

## Mechanism

`ptz_component` is only looked up when the property carries a `TZID`, so a value with neither `TZID` nor a `Z` designator -- floating time, RFC 5545 §3.3.5 form #1 -- reaches `ical_itime_to_utc()` with no zone at all, and `timegm()` declares the wall clock to be UTC. That is deliberate, and `oxcical_import_internal()` says so at the `DTSTART` call site:

```c
/*
 * EXC2019 treats iCalendar floating time as if it was specified with
 * UTC time. As a result, export of such MAPI objects can shift it.
 */
```

The parity is not in question here; the silence is. An appointment written as 10:30 by an author two hours east is stored as 10:30Z and shown by every client as 12:30, and the stored object is then indistinguishable from an appointment that really was UTC: no VTIMEZONE explains the instant, and no property records the hour that was meant. It cannot be repaired afterwards without an outside witness such as the original invitation mail, and until someone finds one, an offset of a few hours reads as a client bug.

## Which store

Neither zcore import wrapper (`cu_ical_to_message`, `cu_ical_to_message2`) set `oxcical_converter::log_id`, and the nested converter in `oxcmail::inet_to_mapi` did not inherit the one its caller had, so import diagnostics named nothing at all -- including the existing `E-2196` line a rejected CalDAV PUT produces. Every other converter in that file is handed a `log_id` built from the store directory, and both import wrappers have the store.

## Change

`W-2746` is logged once per object rather than once per property, so a long series does not repeat the same finding, and `VALUE=DATE` is excluded because floating is the correct state for an all-day event. The two wrappers pass the store directory, and the one line that reports an import failure prints it.

Resolving floating time against the mailbox owner's zone (`PR_EC_USER_TIMEZONE`) would follow the RFC more closely but would disagree with Exchange on identical input; that is not attempted here.

## Test

`tests/utiltest` gains `t_floating_dt`, which points `mlog_init()` at a temporary file and reads it back, so the warning is asserted rather than assumed, and pins the reading as well (`PR_START_DATE` is the wall clock taken verbatim as UTC). Without the first commit it fails with `log.find("W-2746") != std::string::npos failed`. No new test program and no build-system change. `make check` passes 3/3.
