### PR TITLE
emsmdb: keep an empty content table loaded so notifications reach it

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Enhancements:
 
 Fixes:
 
+* emsmdb: Opening a folder that has no contents no longer misses notifications.
 * The rule processor executes Extended Rules' OP_MOVE/OP_COPY now and matches
   string restrictions across PT_STRING8↔PT_UNICODE.
 * During MAPI-to-iCalender conversions, TZID is now omitted when exporting

--- a/exch/emsmdb/oxcfold.cpp
+++ b/exch/emsmdb/oxcfold.cpp
@@ -875,6 +875,14 @@ ec_error_t rop_getcontentstable(uint8_t table_flags, uint32_t *prow_count,
 		return aoh_to_error(hnd);
 	rtable->set_handle(hnd);
 	*phout = hnd;
+	/*
+	 * An empty table is loaded whatever the flags say. See
+	 * table_object::load_if_empty for why it has to exist before the client
+	 * asks for rows; with no rows to insert, the load is free.
+	 */
+	if (!b_conversation && pfolder->type != FOLDER_SEARCH &&
+	    *prow_count == 0)
+		return rtable->load();
 	if (table_flags & MAPI_DEFERRED_ERRORS)
 		/* Inaccurate rowcount permissible under OXCFOLD v23.2 §2.2.1.14.1 */
 		return ecSuccess;

--- a/exch/emsmdb/oxctabl.cpp
+++ b/exch/emsmdb/oxctabl.cpp
@@ -186,6 +186,9 @@ ec_error_t rop_sorttable(uint8_t table_flags, const SORTORDER_SET *psort_criteri
 		return err;
 	*ptable_status = TBLSTAT_COMPLETE;
 	ptable->unload();
+	err = ptable->load_if_empty();
+	if (err != ecSuccess)
+		return err;
 	/* MS-OXCTABL 3.2.5.3 */
 	ptable->clear_bookmarks();
 	ptable->clear_position();
@@ -321,9 +324,11 @@ ec_error_t rop_queryposition(uint32_t *pnumerator, uint32_t *pdenominator,
 	 * The numerator is the cursor, which the table object tracks on its
 	 * own, and for a plain contents table the denominator is available from
 	 * a single count(*), so neither integer needs the folder materialized.
+	 * An empty table is loaded regardless, see table_object::load_if_empty.
 	 */
 	uint32_t total = 0;
-	if (!ptable->is_loaded() && ptable->total_without_load(&total)) {
+	if (!ptable->is_loaded() && ptable->total_without_load(&total) &&
+	    total != 0) {
 		*pnumerator = ptable->get_position();
 		*pdenominator = total;
 		return ecSuccess;

--- a/exch/emsmdb/table_object.cpp
+++ b/exch/emsmdb/table_object.cpp
@@ -268,6 +268,21 @@ bool table_object::total_without_load(uint32_t *pcount) const
 	       b_fai, b_del, pcount);
 }
 
+/**
+ * An unloaded table has no counterpart in exmdb, and exmdb sends its
+ * table notifications to that counterpart. A client with rows to show has to
+ * fetch them, and the fetch loads the table. An empty table is only ever
+ * observed through notifications, so it has to exist from the start. Loading
+ * it costs one indexed count and an empty scan.
+ */
+ec_error_t table_object::load_if_empty()
+{
+	uint32_t total = 0;
+	if (m_loaded || !total_without_load(&total) || total != 0)
+		return ecSuccess;
+	return load();
+}
+
 uint32_t table_object::get_total()
 {
 	if (m_deleted)

--- a/exch/emsmdb/table_object.hpp
+++ b/exch/emsmdb/table_object.hpp
@@ -37,6 +37,7 @@ struct table_object {
 	void clear_position() { m_position = 0; }
 	uint32_t get_total();
 	bool total_without_load(uint32_t *) const;
+	ec_error_t load_if_empty();
 	ec_error_t create_bookmark(uint32_t *pindex);
 	void remove_bookmark(uint32_t index);
 	void clear_bookmarks() { bookmark_list.clear(); }


### PR DESCRIPTION
## What happens

Open the contents table of an empty folder with MFCMAPI and create a message in it. The message does not appear in the table. Reported in #350 against gromox-3.10-93-g1f529d2da.

## Why

exmdb addresses its table notifications to the table objects it holds; `dbeng_notify_cttbl_add_row` walks `dbase.tables.table_list` to find them. A content table that emsmdb has not loaded has no such object, so a message created in that folder produces no notification for the client's table handle.

Two commits made that load lazy: 7711caccd stopped `ropGetContentsTable` from building the table to count it, and 69657ddf9 lets `ropQueryPosition` answer from a count without loading. Both rely on the client fetching rows, which loads the table. A client with rows to show has to do that before it can observe anything. An empty table is the case where nothing forces a load: there are no rows to fetch, and the only way the client can learn of the first one is the notification that needs the table to exist.

## The change

An empty content table is loaded right away, on open, when a sort unloads it, and when its position is queried. `table_object::load_if_empty` does the second and third; `ropGetContentsTable` uses the count it already has and does so ahead of the `MAPI_DEFERRED_ERRORS` early return, so a client that opens with that flag gets the table too, which that path never did. Loading an empty table costs one indexed count and an empty scan. Populated tables keep the deferred load and its savings, and search folders keep loading on open as before.

A table that a restriction leaves empty is still loaded only when the client asks for rows or position, because knowing that it is empty would require the load in the first place.
