### PR TITLE
mapi_lib: restore the vCal-Uid bytes of ThirdPartyGlobalId

### DIFF
--- a/lib/guid2.cpp
+++ b/lib/guid2.cpp
@@ -202,8 +202,7 @@ const uint8_t MACBINARY_ENCODING[9] =
 const uint8_t OLE_TAG[11] =
 	{0x2A, 0x86, 0x48, 0x86, 0xF7, 0x14, 0x03, 0x0A,
 	0x03, 0x02, 0x01};
-/* actually for iCal, not vCard */
-const uint8_t ThirdPartyGlobalId[12] = "vCard-uid\x01"; // 7643616C2D55696401000000
+const uint8_t ThirdPartyGlobalId[12] = "vCal-Uid\x01"; // 7643616C2D55696401000000
 const char IPM_Appointment_Exception[] = "IPM.OLE.CLASS.{00061055-0000-0000-C000-000000000046}";
 static GUID machine_guid;
 static std::once_flag machine_guid_loaded;


### PR DESCRIPTION
`ad03530a0` rewrote the marker as a string literal spelling `vCard-uid` where the bytes read `vCal-Uid`, so `prime` stamps and matches `76436172642D756964010000` instead of `7643616C2D55696401000000` -- the hex in the comment on that line still records the latter.

`oxcical_parse_uid()` and `uid_to_goid()` write the marker and `GLOBALOBJECTID::third_party_uid()` matches it, so objects written since are marked in a way nothing else looks for, while objects written before, or by Outlook, no longer resolve to their UID and fall back to the hex-encoded blob -- in CalDAV that is the href of the event. `tests/utiltest` fails on `prime` at the assertion that came in with #343, and passes with this.
